### PR TITLE
Implement Interface System - Create GameInterface, Renew GameAgent for new Deck System

### DIFF
--- a/Sources/Agents/AgentStructures.cpp
+++ b/Sources/Agents/AgentStructures.cpp
@@ -37,7 +37,7 @@ namespace Hearthstonepp
 		// Do Nothing
 	}
 
-	BeginFirstStructure::BeginFirstStructure(std::string* userFirst, std::string* userLast)
+	BeginFirstStructure::BeginFirstStructure(std::string userFirst, std::string userLast)
 		: m_userFirst(userFirst)
 		, m_userLast(userLast)
 	{

--- a/Sources/Agents/AgentStructures.cpp
+++ b/Sources/Agents/AgentStructures.cpp
@@ -19,12 +19,12 @@ namespace Hearthstonepp
 		Deck* tmpDeck = player->GetDeck(deckID);
 		CardClass cardclass = tmpDeck->GetClass();
 
-		const Card* hero = cards->FindCardByID(std::move(ConvertFromCardClassToHeroID.at(cardclass)));
-		const Card* power = cards->FindCardByID(std::move(ConvertFromCardClassToHeroPowerID.at(cardclass)));
+		const Card* heroCard = cards->FindCardByID(std::move(ConvertFromCardClassToHeroID.at(cardclass)));
+		const Card* powerCard = cards->FindCardByID(std::move(ConvertFromCardClassToHeroPowerID.at(cardclass)));
 
 		deck = tmpDeck->GetPrimitiveDeck();
-		hero = static_cast<Hero*>(const_cast<Card*>(hero));
-		power = static_cast<HeroPower*>(const_cast<Card*>(power));
+		hero = static_cast<Hero*>(const_cast<Card*>(heroCard));
+		power = static_cast<HeroPower*>(const_cast<Card*>(powerCard));
 	}
 
 	DrawStructure::DrawStructure(BYTE drawID, BYTE userID, BYTE numDraw, BYTE numHands, Card** cards)

--- a/Sources/Agents/AgentStructures.cpp
+++ b/Sources/Agents/AgentStructures.cpp
@@ -10,48 +10,48 @@
 
 namespace Hearthstonepp
 {
-	User::User(Player *player, int deckID)
+	User::User(Player* player, int deckID)
+		: m_player(player)
+		, m_weapon(nullptr)
 	{
-		Cards *cards = Cards::GetInstance();
+		Cards* cards = Cards::GetInstance();
 
-		Deck *tmpDeck = player->GetDeck(deckID);
+		Deck* tmpDeck = player->GetDeck(deckID);
 		CardClass cardclass = tmpDeck->GetClass();
 
-		const Card *hero = cards->FindCardByID(std::move(ConvertFromCardClassToHeroID.at(cardclass)));
-		const Card *power = cards->FindCardByID(std::move(ConvertFromCardClassToHeroPowerID.at(cardclass)));
+		const Card* hero = cards->FindCardByID(std::move(ConvertFromCardClassToHeroID.at(cardclass)));
+		const Card* power = cards->FindCardByID(std::move(ConvertFromCardClassToHeroPowerID.at(cardclass)));
 
-		m_player = player;
 		m_deck = tmpDeck->GetPrimitiveDeck();
 		m_hero = static_cast<Hero*>(const_cast<Card*>(hero));
 		m_power = static_cast<HeroPower*>(const_cast<Card*>(power));
-		m_weapon = nullptr;
 	}
 
 	DrawStructure::DrawStructure(BYTE drawID, BYTE userID, BYTE numDraw, BYTE numHands, Card** cards)
-		: m_id(drawID)
-		, m_userID(userID)
-		, m_numDraw(numDraw)
-		, m_numHands(numHands)
-		, m_cards(cards)
+		: id(drawID)
+		, userID(userID)
+		, numDraw(numDraw)
+		, numHands(numHands)
+		, cards(cards)
 	{
 		// Do Nothing
 	}
 
 	BeginFirstStructure::BeginFirstStructure(std::string userFirst, std::string userLast)
-		: m_userFirst(userFirst)
-		, m_userLast(userLast)
+		: userFirst(userFirst)
+		, userLast(userLast)
 	{
 		// Do Nothing
 	}
 
 	BeginShuffleStructure::BeginShuffleStructure(int userID)
-		: m_userID(userID)
+		: userID(userID)
 	{
 		// Do Nothing
 	}
 
 	BeginMulliganStructure::BeginMulliganStructure(int userID)
-		: m_userID(userID)
+		: userID(userID)
 	{
 		// Do Nothing
 	}

--- a/Sources/Agents/AgentStructures.cpp
+++ b/Sources/Agents/AgentStructures.cpp
@@ -11,8 +11,8 @@
 namespace Hearthstonepp
 {
 	User::User(Player* player, int deckID)
-		: m_player(player)
-		, m_weapon(nullptr)
+		: player(player)
+		, weapon(nullptr)
 	{
 		Cards* cards = Cards::GetInstance();
 
@@ -22,9 +22,9 @@ namespace Hearthstonepp
 		const Card* hero = cards->FindCardByID(std::move(ConvertFromCardClassToHeroID.at(cardclass)));
 		const Card* power = cards->FindCardByID(std::move(ConvertFromCardClassToHeroPowerID.at(cardclass)));
 
-		m_deck = tmpDeck->GetPrimitiveDeck();
-		m_hero = static_cast<Hero*>(const_cast<Card*>(hero));
-		m_power = static_cast<HeroPower*>(const_cast<Card*>(power));
+		deck = tmpDeck->GetPrimitiveDeck();
+		hero = static_cast<Hero*>(const_cast<Card*>(hero));
+		power = static_cast<HeroPower*>(const_cast<Card*>(power));
 	}
 
 	DrawStructure::DrawStructure(BYTE drawID, BYTE userID, BYTE numDraw, BYTE numHands, Card** cards)

--- a/Sources/Agents/AgentStructures.cpp
+++ b/Sources/Agents/AgentStructures.cpp
@@ -1,0 +1,58 @@
+/*************************************************************************
+> File Name: AgentStructure.cpp
+> Project Name: Hearthstone++
+> Author: Young-Joong Kim
+> Purpose: Agent Data Structure for Interact with Interface
+> Created Time: 2017/10/24
+> Copyright (c) 2017, Young-Joong Kim
+*************************************************************************/
+#include <Agents/AgentStructures.h>
+
+namespace Hearthstonepp
+{
+	User::User(Player *player, int deckID)
+	{
+		Cards *cards = Cards::GetInstance();
+
+		Deck *tmpDeck = player->GetDeck(deckID);
+		CardClass cardclass = tmpDeck->GetClass();
+
+		const Card *hero = cards->FindCardByID(std::move(ConvertFromCardClassToHeroID.at(cardclass)));
+		const Card *power = cards->FindCardByID(std::move(ConvertFromCardClassToHeroPowerID.at(cardclass)));
+
+		m_player = player;
+		m_deck = tmpDeck->GetPrimitiveDeck();
+		m_hero = static_cast<Hero*>(const_cast<Card*>(hero));
+		m_power = static_cast<HeroPower*>(const_cast<Card*>(power));
+		m_weapon = nullptr;
+	}
+
+	DrawStructure::DrawStructure(BYTE drawID, BYTE userID, BYTE numDraw, BYTE numHands, Card** cards)
+		: m_id(drawID)
+		, m_userID(userID)
+		, m_numDraw(numDraw)
+		, m_numHands(numHands)
+		, m_cards(cards)
+	{
+		// Do Nothing
+	}
+
+	BeginFirstStructure::BeginFirstStructure(std::string* userFirst, std::string* userLast)
+		: m_userFirst(userFirst)
+		, m_userLast(userLast)
+	{
+		// Do Nothing
+	}
+
+	BeginShuffleStructure::BeginShuffleStructure(int userID)
+		: m_userID(userID)
+	{
+		// Do Nothing
+	}
+
+	BeginMulliganStructure::BeginMulliganStructure(int userID)
+		: m_userID(userID)
+	{
+		// Do Nothing
+	}
+}

--- a/Sources/Agents/AgentStructures.h
+++ b/Sources/Agents/AgentStructures.h
@@ -25,13 +25,13 @@ namespace Hearthstonepp
 	class User
 	{
 	public:
-		User(Player *player, int deckID);
+		User(Player* player, int deckID);
 
 		int m_id;
-		Player *m_player;
-		Hero *m_hero;
-		HeroPower *m_power;
-		Weapon *m_weapon;
+		Player* m_player;
+		Hero* m_hero;
+		HeroPower* m_power;
+		Weapon* m_weapon;
 
 		std::vector<Card*> m_deck;
 		std::vector<Card*> m_field;
@@ -49,36 +49,36 @@ namespace Hearthstonepp
 	{
 		DrawStructure(BYTE drawID, BYTE userID, BYTE numDraw, BYTE numHands, Card** cards);
 
-		BYTE m_id;
-		BYTE m_userID;
-		BYTE m_numDraw;
-		BYTE m_numHands;
-		Card** m_cards;
+		BYTE id;
+		BYTE userID;
+		BYTE numDraw;
+		BYTE numHands;
+		Card** cards;
 	};
 
 	struct BeginFirstStructure
 	{
 		BeginFirstStructure(std::string userFirst, std::string userLast);
 
-		BYTE m_id = static_cast<BYTE>(Step::BEGIN_FIRST);
-		std::string m_userFirst;
-		std::string m_userLast;
+		BYTE id = static_cast<BYTE>(Step::BEGIN_FIRST);
+		std::string userFirst;
+		std::string userLast;
 	};
 
 	struct BeginShuffleStructure
 	{
 		BeginShuffleStructure(int userID);
 
-		BYTE m_id = static_cast<BYTE>(Step::BEGIN_SHUFFLE);
-		int m_userID;
+		BYTE id = static_cast<BYTE>(Step::BEGIN_SHUFFLE);
+		int userID;
 	};
 
 	struct BeginMulliganStructure
 	{
 		BeginMulliganStructure(int userID);
 
-		BYTE m_id = static_cast<BYTE>(Step::BEGIN_MULLIGAN);
-		int m_userID;
+		BYTE id = static_cast<BYTE>(Step::BEGIN_MULLIGAN);
+		int userID;
 	};
 }
 

--- a/Sources/Agents/AgentStructures.h
+++ b/Sources/Agents/AgentStructures.h
@@ -58,11 +58,11 @@ namespace Hearthstonepp
 
 	struct BeginFirstStructure
 	{
-		BeginFirstStructure(std::string* userFirst, std::string* userLast);
+		BeginFirstStructure(std::string userFirst, std::string userLast);
 
 		BYTE m_id = static_cast<BYTE>(Step::BEGIN_FIRST);
-		std::string* m_userFirst;
-		std::string* m_userLast;
+		std::string m_userFirst;
+		std::string m_userLast;
 	};
 
 	struct BeginShuffleStructure

--- a/Sources/Agents/AgentStructures.h
+++ b/Sources/Agents/AgentStructures.h
@@ -22,22 +22,21 @@ namespace Hearthstonepp
 {
 	using BYTE = unsigned char;
 
-	class User
+	struct User
 	{
-	public:
 		User(Player* player, int deckID);
 
-		int m_id;
-		Player* m_player;
-		Hero* m_hero;
-		HeroPower* m_power;
-		Weapon* m_weapon;
+		int id;
+		Player* player;
+		Hero* hero;
+		HeroPower* power;
+		Weapon* weapon;
 
-		std::vector<Card*> m_deck;
-		std::vector<Card*> m_field;
-		std::vector<Card*> m_hand;
-		std::vector<Card*> m_usedSpell;
-		std::vector<Card*> m_usedMinion;
+		std::vector<Card*> deck;
+		std::vector<Card*> field;
+		std::vector<Card*> hand;
+		std::vector<Card*> usedSpell;
+		std::vector<Card*> usedMinion;
 	};
 
 	struct GameResult

--- a/Sources/Agents/AgentStructures.h
+++ b/Sources/Agents/AgentStructures.h
@@ -1,0 +1,85 @@
+/*************************************************************************
+> File Name: AgentStructure.h
+> Project Name: Hearthstone++
+> Author: Young-Joong Kim
+> Purpose: Agent Data Structure for Interact with Interface
+> Created Time: 2017/10/24
+> Copyright (c) 2017, Young-Joong Kim
+*************************************************************************/
+#ifndef HEARTHSTONEPP_AGENT_STRUCTURES_H
+#define HEARTHSTONEPP_AGENT_STRUCTURES_H
+
+#include <Enums/EnumsToString.h>
+#include <Models/Card.h>
+#include <Models/Cards.h>
+#include <Models/Deck.h>
+#include <Models/Entities/Hero.h>
+#include <Models/Entities/HeroPower.h>
+#include <Models/Entities/Weapon.h>
+#include <Models/Player.h>
+
+namespace Hearthstonepp
+{
+	using BYTE = unsigned char;
+
+	class User
+	{
+	public:
+		User(Player *player, int deckID);
+
+		int m_id;
+		Player *m_player;
+		Hero *m_hero;
+		HeroPower *m_power;
+		Weapon *m_weapon;
+
+		std::vector<Card*> m_deck;
+		std::vector<Card*> m_field;
+		std::vector<Card*> m_hand;
+		std::vector<Card*> m_usedSpell;
+		std::vector<Card*> m_usedMinion;
+	};
+
+	struct GameResult
+	{
+
+	};
+
+	struct DrawStructure
+	{
+		DrawStructure(BYTE drawID, BYTE userID, BYTE numDraw, BYTE numHands, Card** cards);
+
+		BYTE m_id;
+		BYTE m_userID;
+		BYTE m_numDraw;
+		BYTE m_numHands;
+		Card** m_cards;
+	};
+
+	struct BeginFirstStructure
+	{
+		BeginFirstStructure(std::string* userFirst, std::string* userLast);
+
+		BYTE m_id = static_cast<BYTE>(Step::BEGIN_FIRST);
+		std::string* m_userFirst;
+		std::string* m_userLast;
+	};
+
+	struct BeginShuffleStructure
+	{
+		BeginShuffleStructure(int userID);
+
+		BYTE m_id = static_cast<BYTE>(Step::BEGIN_SHUFFLE);
+		int m_userID;
+	};
+
+	struct BeginMulliganStructure
+	{
+		BeginMulliganStructure(int userID);
+
+		BYTE m_id = static_cast<BYTE>(Step::BEGIN_MULLIGAN);
+		int m_userID;
+	};
+}
+
+#endif

--- a/Sources/Agents/GameAgent.cpp
+++ b/Sources/Agents/GameAgent.cpp
@@ -28,21 +28,21 @@ namespace Hearthstonepp
 	}
 
 	GameAgent::GameAgent(User& user1, User& user2, int maxBufferSize)
-		: userCurrent(user1)
-		, userOpponent(user2)
-		, inBuffer(maxBufferSize) // initialize pipe buffer
-		, outBuffer(maxBufferSize)
-		, generator(rd()) // initialize random generator
+		: m_userCurrent(user1)
+		, m_userOpponent(user2)
+		, m_inBuffer(maxBufferSize) // initialize pipe buffer
+		, m_outBuffer(maxBufferSize)
+		, m_generator(m_rd()) // initialize random generator
 	{
 		// Do Nothing
 	}
 
 	GameAgent::GameAgent(User&& user1, User&& user2, int maxBufferSize)
-		: userCurrent(std::move(user1))
-		, userOpponent(std::move(user2))
-		, inBuffer(maxBufferSize) // initialize pipe buffer
-		, outBuffer(maxBufferSize)
-		, generator(rd()) // initialize random generator
+		: m_userCurrent(std::move(user1))
+		, m_userOpponent(std::move(user2))
+		, m_inBuffer(maxBufferSize) // initialize pipe buffer
+		, m_outBuffer(maxBufferSize)
+		, m_generator(m_rd()) // initialize random generator
 	{
 		// Do Nothing
 	}
@@ -69,16 +69,16 @@ namespace Hearthstonepp
 		// userOpponent : user who start later
 		DecideDeckOrder();
 
-		ShuffleDeck(userCurrent);
-		ShuffleDeck(userOpponent);
+		ShuffleDeck(m_userCurrent);
+		ShuffleDeck(m_userOpponent);
 
-		Draw(userCurrent, 3);
-		Draw(userOpponent, 3);
+		Draw(m_userCurrent, 3);
+		Draw(m_userOpponent, 3);
 
-		Mulligan(userCurrent);
-		Mulligan(userOpponent);
+		Mulligan(m_userCurrent);
+		Mulligan(m_userOpponent);
 
-		userOpponent.hand.push_back(new Card()); // Coin for later user
+		m_userOpponent.hand.push_back(new Card()); // Coin for later user
 	}
 
 	void GameAgent::MainPhase()
@@ -95,16 +95,16 @@ namespace Hearthstonepp
 	{
 		// get random number, zero or one.
 		std::uniform_int_distribution<int> bin(0, 1);
-		if (bin(generator) == 1) // swap user with 50% probability
+		if (bin(m_generator) == 1) // swap user with 50% probability
 		{
-			std::swap(userCurrent, userOpponent);
+			std::swap(m_userCurrent, m_userOpponent);
 		}
 	}
 
 	void GameAgent::ShuffleDeck(User& user)
 	{
 		std::vector<Card*>& deck = user.deck;
-		std::shuffle(deck.begin(), deck.end(), generator); // shuffle with random generator
+		std::shuffle(deck.begin(), deck.end(), m_generator); // shuffle with random generator
 	}
 
 	void GameAgent::Mulligan(User& user)
@@ -158,21 +158,21 @@ namespace Hearthstonepp
 
 	int GameAgent::ReadBuffer(BYTE *arr, int maxSize)
 	{
-		return outBuffer.ReadBuffer(arr, maxSize);
+		return m_outBuffer.ReadBuffer(arr, maxSize);
 	}
 
 	int GameAgent::WriteBuffer(BYTE *arr, int size)
 	{
-		return inBuffer.WriteBuffer(arr, size);
+		return m_inBuffer.WriteBuffer(arr, size);
 	}
 
 	int GameAgent::ReadInputBuffer(BYTE* arr, int maxSize)
 	{
-		return inBuffer.ReadBuffer(arr, maxSize);
+		return m_inBuffer.ReadBuffer(arr, maxSize);
 	}
 
 	int GameAgent::WriteOutputBuffer(BYTE* arr, int size)
 	{
-		return outBuffer.WriteBuffer(arr, size);
+		return m_outBuffer.WriteBuffer(arr, size);
 	}
 }

--- a/Sources/Agents/GameAgent.cpp
+++ b/Sources/Agents/GameAgent.cpp
@@ -89,8 +89,8 @@ namespace Hearthstonepp
 		m_userCurrent.m_id = 0;
 		m_userOpponent.m_id = 1;
 
-		std::string *userFirst = &m_userCurrent.m_player->GetID();
-		std::string *userLast = &m_userOpponent.m_player->GetID();
+		std::string& userFirst = m_userCurrent.m_player->GetID();
+		std::string& userLast = m_userOpponent.m_player->GetID();
 
 		BeginFirstStructure data(userFirst, userLast);
 		WriteOutputBuffer((BYTE*)&data, sizeof(BeginFirstStructure));

--- a/Sources/Agents/GameAgent.cpp
+++ b/Sources/Agents/GameAgent.cpp
@@ -34,7 +34,7 @@ namespace Hearthstonepp
 
 	std::thread* GameAgent::StartAgent(GameResult& result)
 	{
-		std::thread *agent = new std::thread([this](GameResult& result) {
+		std::thread* agent = new std::thread([this](GameResult& result) {
 			BeginPhase();
 
 			while (!IsGameEnd())
@@ -107,10 +107,10 @@ namespace Hearthstonepp
 
 	void GameAgent::BeginDraw(User& user)
 	{
-		Draw(user, 3);
+		Draw(user, NUM_BEGIN_DRAW);
 
 		Card** hand = user.m_hand.data();
-		DrawStructure data(static_cast<BYTE>(Step::BEGIN_DRAW), user.m_id, 3, 3, hand);
+		DrawStructure data(static_cast<BYTE>(Step::BEGIN_DRAW), user.m_id, NUM_BEGIN_DRAW, NUM_BEGIN_DRAW, hand);
 		WriteOutputBuffer((BYTE*)&data, sizeof(DrawStructure));
 	}
 
@@ -119,8 +119,8 @@ namespace Hearthstonepp
 		BeginMulliganStructure data(user.m_id);
 		WriteOutputBuffer((BYTE*)&data, sizeof(BeginMulliganStructure));
 
-		BYTE index[3] = { 0, };	
-		int read = ReadInputBuffer(index, 3); // read index of the card to be mulligan
+		BYTE index[NUM_BEGIN_DRAW] = { 0, };
+		int read = ReadInputBuffer(index, NUM_BEGIN_DRAW); // read index of the card to be mulligan
 
 		std::vector<Card*>& deck = user.m_deck;
 		std::vector<Card*>& hand = user.m_hand;
@@ -135,7 +135,7 @@ namespace Hearthstonepp
 		std::shuffle(deck.begin(), deck.end(), m_generator);
 
 		Draw(user, read);
-		DrawStructure data2(static_cast<BYTE>(Step::BEGIN_MULLIGAN), user.m_id, read, 3, hand.data());
+		DrawStructure data2(static_cast<BYTE>(Step::BEGIN_MULLIGAN), user.m_id, read, NUM_BEGIN_DRAW, hand.data());
 		WriteOutputBuffer((BYTE*)&data2, sizeof(DrawStructure)); // send new card data
 	}
 
@@ -174,12 +174,12 @@ namespace Hearthstonepp
 		return m_bufferCapacity;
 	}
 
-	int GameAgent::ReadBuffer(BYTE *arr, int maxSize)
+	int GameAgent::ReadBuffer(BYTE* arr, int maxSize)
 	{
 		return m_outBuffer.ReadBuffer(arr, maxSize);
 	}
 
-	int GameAgent::WriteBuffer(BYTE *arr, int size)
+	int GameAgent::WriteBuffer(BYTE* arr, int size)
 	{
 		return m_inBuffer.WriteBuffer(arr, size);
 	}

--- a/Sources/Agents/GameAgent.cpp
+++ b/Sources/Agents/GameAgent.cpp
@@ -122,12 +122,17 @@ namespace Hearthstonepp
 		BYTE index[3] = { 0, };	
 		int read = ReadInputBuffer(index, 3); // read index of the card to be mulligan
 
+		std::vector<Card*>& deck = user.m_deck;
 		std::vector<Card*>& hand = user.m_hand;
+
 		std::sort(index, index + read, std::greater<int>());
 		for (int i = 0; i < read; ++i)
 		{
+			deck.emplace_back(hand[index[i]]);
 			hand.erase(hand.begin() + index[i]); // erase card with given index
 		}
+
+		std::shuffle(deck.begin(), deck.end(), m_generator);
 
 		Draw(user, read);
 		DrawStructure data2(static_cast<BYTE>(Step::BEGIN_MULLIGAN), user.m_id, read, 3, hand.data());

--- a/Sources/Agents/GameAgent.cpp
+++ b/Sources/Agents/GameAgent.cpp
@@ -37,6 +37,16 @@ namespace Hearthstonepp
 		// Do Nothing
 	}
 
+	GameAgent::GameAgent(User&& user1, User&& user2, int maxBufferSize)
+		: userCurrent(std::move(user1))
+		, userOpponent(std::move(user2))
+		, inBuffer(maxBufferSize) // initialize pipe buffer
+		, outBuffer(maxBufferSize)
+		, generator(rd()) // initialize random generator
+	{
+		// Do Nothing
+	}
+
 	std::thread* GameAgent::StartAgent(GameResult& result)
 	{
 		std::thread *agent = new std::thread([this](GameResult& result) {
@@ -120,8 +130,8 @@ namespace Hearthstonepp
 	{
 		return true;
 		/*
-		int healthCurrent = userCurrent->hero->health;
-		int healthOpponent = userOpponent->hero->health;
+		int healthCurrent = userCurrent.hero->health;
+		int healthOpponent = userOpponent.hero->health;
 
 		if (healthCurrent <= 0 || healthOpponent <= 0)
 		{

--- a/Sources/Agents/GameAgent.cpp
+++ b/Sources/Agents/GameAgent.cpp
@@ -63,7 +63,7 @@ namespace Hearthstonepp
 		Mulligan(m_userCurrent);
 		Mulligan(m_userOpponent);
 
-		m_userOpponent.m_hand.push_back(new Card()); // Coin for later user
+		m_userOpponent.hand.push_back(new Card()); // Coin for later user
 	}
 
 	void GameAgent::MainPhase()
@@ -86,11 +86,11 @@ namespace Hearthstonepp
 			std::swap(m_userCurrent, m_userOpponent);
 		}
 
-		m_userCurrent.m_id = 0;
-		m_userOpponent.m_id = 1;
+		m_userCurrent.id = 0;
+		m_userOpponent.id = 1;
 
-		std::string& userFirst = m_userCurrent.m_player->GetID();
-		std::string& userLast = m_userOpponent.m_player->GetID();
+		std::string& userFirst = m_userCurrent.player->GetID();
+		std::string& userLast = m_userOpponent.player->GetID();
 
 		BeginFirstStructure data(userFirst, userLast);
 		WriteOutputBuffer((BYTE*)&data, sizeof(BeginFirstStructure));
@@ -98,10 +98,10 @@ namespace Hearthstonepp
 
 	void GameAgent::ShuffleDeck(User& user)
 	{
-		std::vector<Card*>& deck = user.m_deck;
+		std::vector<Card*>& deck = user.deck;
 		std::shuffle(deck.begin(), deck.end(), m_generator); // shuffle with random generator
 
-		BeginShuffleStructure data(user.m_id);
+		BeginShuffleStructure data(user.id);
 		WriteOutputBuffer((BYTE*)&data, sizeof(BeginShuffleStructure));
 	}
 
@@ -109,21 +109,21 @@ namespace Hearthstonepp
 	{
 		Draw(user, NUM_BEGIN_DRAW);
 
-		Card** hand = user.m_hand.data();
-		DrawStructure data(static_cast<BYTE>(Step::BEGIN_DRAW), user.m_id, NUM_BEGIN_DRAW, NUM_BEGIN_DRAW, hand);
+		Card** hand = user.hand.data();
+		DrawStructure data(static_cast<BYTE>(Step::BEGIN_DRAW), user.id, NUM_BEGIN_DRAW, NUM_BEGIN_DRAW, hand);
 		WriteOutputBuffer((BYTE*)&data, sizeof(DrawStructure));
 	}
 
 	void GameAgent::Mulligan(User& user)
 	{
-		BeginMulliganStructure data(user.m_id);
+		BeginMulliganStructure data(user.id);
 		WriteOutputBuffer((BYTE*)&data, sizeof(BeginMulliganStructure));
 
 		BYTE index[NUM_BEGIN_DRAW] = { 0, };
 		int read = ReadInputBuffer(index, NUM_BEGIN_DRAW); // read index of the card to be mulligan
 
-		std::vector<Card*>& deck = user.m_deck;
-		std::vector<Card*>& hand = user.m_hand;
+		std::vector<Card*>& deck = user.deck;
+		std::vector<Card*>& hand = user.hand;
 
 		std::sort(index, index + read, std::greater<int>());
 		for (int i = 0; i < read; ++i)
@@ -135,7 +135,7 @@ namespace Hearthstonepp
 		std::shuffle(deck.begin(), deck.end(), m_generator);
 
 		Draw(user, read);
-		DrawStructure data2(static_cast<BYTE>(Step::BEGIN_MULLIGAN), user.m_id, read, NUM_BEGIN_DRAW, hand.data());
+		DrawStructure data2(static_cast<BYTE>(Step::BEGIN_MULLIGAN), user.id, read, NUM_BEGIN_DRAW, hand.data());
 		WriteOutputBuffer((BYTE*)&data2, sizeof(DrawStructure)); // send new card data
 	}
 
@@ -159,8 +159,8 @@ namespace Hearthstonepp
 
 	void GameAgent::Draw(User& user, int num)
 	{
-		std::vector<Card*>& deck = user.m_deck;
-		std::vector<Card*>& hand = user.m_hand;
+		std::vector<Card*>& deck = user.deck;
+		std::vector<Card*>& hand = user.hand;
 
 		for (int i = 0; i < num; ++i)
 		{

--- a/Sources/Agents/GameAgent.h
+++ b/Sources/Agents/GameAgent.h
@@ -9,8 +9,8 @@
 #ifndef HEARTHSTONEPP_GAME_AGENT_H
 #define HEARTHSTONEPP_GAME_AGENT_H
 
-#include <Agents/Interface.h>
 #include <Enums/EnumsToString.h>
+#include <Interface/InteractBuffer.h>
 #include <Models/Card.h>
 #include <Models/Cards.h>
 #include <Models/Deck.h>

--- a/Sources/Agents/GameAgent.h
+++ b/Sources/Agents/GameAgent.h
@@ -61,14 +61,14 @@ namespace Hearthstonepp
 		int WriteBuffer(BYTE* arr, int size); // Write data to Agent
 
 	private:
-		User userCurrent;
-		User userOpponent;
+		User m_userCurrent;
+		User m_userOpponent;
 
-		InteractBuffer inBuffer; // Pipe IO : User -> Agent 
-		InteractBuffer outBuffer; // Pipe IO : Agent -> User
+		InteractBuffer m_inBuffer; // Pipe IO : User -> Agent 
+		InteractBuffer m_outBuffer; // Pipe IO : Agent -> User
 
-		std::random_device rd;
-		std::default_random_engine generator; // random generator
+		std::random_device m_rd;
+		std::default_random_engine m_generator; // random generator
 
 		int ReadInputBuffer(BYTE* arr, int maxSize); // Read data written by User
 		int WriteOutputBuffer(BYTE* arr, int size); // Write data to User

--- a/Sources/Agents/GameAgent.h
+++ b/Sources/Agents/GameAgent.h
@@ -9,15 +9,8 @@
 #ifndef HEARTHSTONEPP_GAME_AGENT_H
 #define HEARTHSTONEPP_GAME_AGENT_H
 
-#include <Enums/EnumsToString.h>
+#include <Agents/AgentStructures.h>
 #include <Interface/InteractBuffer.h>
-#include <Models/Card.h>
-#include <Models/Cards.h>
-#include <Models/Deck.h>
-#include <Models/Entities/Hero.h>
-#include <Models/Entities/HeroPower.h>
-#include <Models/Entities/Weapon.h>
-#include <Models/Player.h>
 
 #include <algorithm>
 #include <random>
@@ -26,30 +19,6 @@
 
 namespace Hearthstonepp
 {
-	using BYTE = unsigned char;
-
-	class User
-	{
-	public:
-		User(Player *player, int deckID);
-
-		Player *player;
-		Hero *hero;
-		HeroPower *power;
-		Weapon *weapon;
-
-		std::vector<Card*> deck;
-		std::vector<Card*> field;
-		std::vector<Card*> hand;
-		std::vector<Card*> usedSpell;
-		std::vector<Card*> usedMinion;
-	};
-
-	struct GameResult
-	{
-
-	};
-
 	class GameAgent
 	{
 	public:
@@ -57,6 +26,7 @@ namespace Hearthstonepp
 		GameAgent(User&& user1, User&& user2, int maxBufferSize = 2048);
 		std::thread* StartAgent(GameResult& result);
 
+		int GetBufferCapacity() const;
 		int ReadBuffer(BYTE* arr, int maxSize); // Read data written by Agent
 		int WriteBuffer(BYTE* arr, int size); // Write data to Agent
 
@@ -64,6 +34,7 @@ namespace Hearthstonepp
 		User m_userCurrent;
 		User m_userOpponent;
 
+		int m_bufferCapacity;
 		InteractBuffer m_inBuffer; // Pipe IO : User -> Agent 
 		InteractBuffer m_outBuffer; // Pipe IO : Agent -> User
 
@@ -82,6 +53,7 @@ namespace Hearthstonepp
 
 		void DecideDeckOrder();
 		void ShuffleDeck(User& user);
+		void BeginDraw(User& user);
 		void Mulligan(User& user);
 	};
 }

--- a/Sources/Agents/GameAgent.h
+++ b/Sources/Agents/GameAgent.h
@@ -10,6 +10,7 @@
 #define HEARTHSTONEPP_GAME_AGENT_H
 
 #include <Agents/AgentStructures.h>
+#include <Commons/Constants.h>
 #include <Interface/InteractBuffer.h>
 
 #include <algorithm>

--- a/Sources/Agents/GameAgent.h
+++ b/Sources/Agents/GameAgent.h
@@ -32,7 +32,6 @@ namespace Hearthstonepp
 	{
 	public:
 		User(Player *player, int deckID);
-		User(User& user) = default;
 
 		Player *player;
 		Hero *hero;
@@ -55,14 +54,15 @@ namespace Hearthstonepp
 	{
 	public:
 		GameAgent(User& user1, User& user2, int maxBufferSize = 2048);
+		GameAgent(User&& user1, User&& user2, int maxBufferSize = 2048);
 		std::thread* StartAgent(GameResult& result);
 
 		int ReadBuffer(BYTE* arr, int maxSize); // Read data written by Agent
 		int WriteBuffer(BYTE* arr, int size); // Write data to Agent
 
 	private:
-		User& userCurrent;
-		User& userOpponent;
+		User userCurrent;
+		User userOpponent;
 
 		InteractBuffer inBuffer; // Pipe IO : User -> Agent 
 		InteractBuffer outBuffer; // Pipe IO : Agent -> User

--- a/Sources/Agents/GameAgent.h
+++ b/Sources/Agents/GameAgent.h
@@ -10,11 +10,14 @@
 #define HEARTHSTONEPP_GAME_AGENT_H
 
 #include <Agents/Interface.h>
+#include <Enums/EnumsToString.h>
 #include <Models/Card.h>
+#include <Models/Cards.h>
 #include <Models/Deck.h>
 #include <Models/Entities/Hero.h>
 #include <Models/Entities/HeroPower.h>
 #include <Models/Entities/Weapon.h>
+#include <Models/Player.h>
 
 #include <algorithm>
 #include <random>
@@ -28,14 +31,15 @@ namespace Hearthstonepp
 	class User
 	{
 	public:
-		User(int id, Hero *hero, HeroPower *power, Deck& deck);
+		User(Player *player, int deckID);
+		User(User& user) = default;
 
-		int id;
+		Player *player;
 		Hero *hero;
 		HeroPower *power;
 		Weapon *weapon;
 
-		Deck deck;
+		std::vector<Card*> deck;
 		std::vector<Card*> field;
 		std::vector<Card*> hand;
 		std::vector<Card*> usedSpell;
@@ -50,15 +54,15 @@ namespace Hearthstonepp
 	class GameAgent
 	{
 	public:
-		GameAgent(User *user1, User *user2, int maxBufferSize = 2048);
+		GameAgent(User& user1, User& user2, int maxBufferSize = 2048);
 		std::thread* StartAgent(GameResult& result);
 
 		int ReadBuffer(BYTE* arr, int maxSize); // Read data written by Agent
 		int WriteBuffer(BYTE* arr, int size); // Write data to Agent
 
 	private:
-		User *userCurrent;
-		User *userOpponent;
+		User& userCurrent;
+		User& userOpponent;
 
 		InteractBuffer inBuffer; // Pipe IO : User -> Agent 
 		InteractBuffer outBuffer; // Pipe IO : Agent -> User
@@ -70,15 +74,15 @@ namespace Hearthstonepp
 		int WriteOutputBuffer(BYTE* arr, int size); // Write data to User
 
 		bool IsGameEnd();
-		void Draw(User *user, int num);
+		void Draw(User& user, int num);
 
 		void BeginPhase();
 		void MainPhase();
 		void FinalPhase(GameResult& result);
 
 		void DecideDeckOrder();
-		void ShuffleDeck(User *user);
-		void Mulligan(User *user);
+		void ShuffleDeck(User& user);
+		void Mulligan(User& user);
 	};
 }
 

--- a/Sources/Agents/Interface.cpp
+++ b/Sources/Agents/Interface.cpp
@@ -11,8 +11,8 @@
 namespace Hearthstonepp
 {
 	InteractBuffer::InteractBuffer(int capacity)
-		: capacity(capacity), head(0), tail(0), usage(0), readable(false)
 	{
+		this->capacity = capacity;
 		buffer = new BYTE[capacity]; // buffer, circular queue
 	}
 

--- a/Sources/Agents/Interface.cpp
+++ b/Sources/Agents/Interface.cpp
@@ -11,13 +11,9 @@
 namespace Hearthstonepp
 {
 	InteractBuffer::InteractBuffer(int capacity)
+		: capacity(capacity), head(0), tail(0), usage(0), readable(false)
 	{
-		this->capacity = capacity; // size of the buffer
-		this->head = 0;
-		this->tail = 0;
-		this->usage = 0; // size of the data in the buffer
-		this->readable = false; // whether the buffer has data
-		this->buffer = new BYTE[capacity]; // buffer, circular queue
+		buffer = new BYTE[capacity]; // buffer, circular queue
 	}
 
 	int InteractBuffer::ReadBuffer(BYTE *data, int maxSize)

--- a/Sources/Agents/Interface.h
+++ b/Sources/Agents/Interface.h
@@ -29,11 +29,12 @@ namespace Hearthstonepp
 		std::condition_variable cv;
 
 		int capacity;
-		bool readable;
+		bool readable = false;
 
 		BYTE *buffer;
-		int usage;
-		int head, tail;
+		int head = 0;
+		int tail = 0;
+		int usage = 0;
 	};
 }
 

--- a/Sources/Agents/Interface.h
+++ b/Sources/Agents/Interface.h
@@ -25,16 +25,16 @@ namespace Hearthstonepp
 		int WriteBuffer(BYTE *data, int size);
 
 	private:
-		std::mutex mtx;
-		std::condition_variable cv;
+		std::mutex m_mtx;
+		std::condition_variable m_cv;
 
-		int capacity;
-		bool readable = false;
+		int m_capacity;
+		bool m_readable = false;
 
-		BYTE *buffer;
-		int head = 0;
-		int tail = 0;
-		int usage = 0;
+		BYTE *m_buffer;
+		int m_head = 0;
+		int m_tail = 0;
+		int m_usage = 0;
 	};
 }
 

--- a/Sources/Agents/Interface.h
+++ b/Sources/Agents/Interface.h
@@ -6,8 +6,8 @@
 > Created Time: 2017/10/04
 > Copyright (c) 2017, Young-Joong Kim
 *************************************************************************/
-#ifndef HEARTHSTONEPP_UTILITY_H
-#define HEARTHSTONEPP_UTILITY_H
+#ifndef HEARTHSTONEPP_INTERFACE_H
+#define HEARTHSTONEPP_INTERFACE_H
 
 #include <condition_variable>
 #include <mutex>
@@ -38,4 +38,4 @@ namespace Hearthstonepp
 	};
 }
 
-#endif HEARTHSTONEPP_UTILITY_H
+#endif

--- a/Sources/Commons/Constants.h
+++ b/Sources/Commons/Constants.h
@@ -20,6 +20,8 @@ namespace Hearthstonepp
 
 	constexpr size_t PLAYER_CLASS_SIZE = 9;
 	constexpr unsigned int MAXIMUM_NUM_CARDS_IN_DECK = 30;
+
+	constexpr unsigned int NUM_BEGIN_DRAW = 3;
 }
 
 #endif

--- a/Sources/Enums/EnumsToString.h
+++ b/Sources/Enums/EnumsToString.h
@@ -91,6 +91,19 @@ namespace Hearthstonepp
 		{ CardClass::NEUTRAL,		"NEUTRAL" }
 	};
 
+	const std::map<const CardClass, const std::string> ConvertFromCardClassToHeroPowerID =
+	{
+		{ CardClass::DRUID, "CS2_017" },
+		{ CardClass::HUNTER, "DS1h_292" },
+		{ CardClass::MAGE, "CS2_034" },
+		{ CardClass::PALADIN, "CS2_101" },
+		{ CardClass::PRIEST, "CS1h_001" },
+		{ CardClass::ROGUE, "CS2_083b" },
+		{ CardClass::SHAMAN, "CS2_049" },
+		{ CardClass::WARLOCK, "CS2_056" },
+		{ CardClass::WARRIOR, "CS2_102" },
+	};
+
 	const std::map<const CardType, const std::string> ConverterFromCardTypeToString =
 	{
 		{ CardType::INVALID,		"INVALID" },

--- a/Sources/Enums/EnumsToString.h
+++ b/Sources/Enums/EnumsToString.h
@@ -91,6 +91,19 @@ namespace Hearthstonepp
 		{ CardClass::NEUTRAL,		"NEUTRAL" }
 	};
 
+	const std::map<const CardClass, const std::string> ConvertFromCardClassToHeroID =
+	{
+		{ CardClass::DRUID, "HERO_06" },
+		{ CardClass::HUNTER, "HERO_05" },
+		{ CardClass::MAGE, "HERO_08" },
+		{ CardClass::PALADIN, "HERO_04" },
+		{ CardClass::PRIEST, "HERO_09" },
+		{ CardClass::ROGUE, "HERO_03" },
+		{ CardClass::SHAMAN, "HERO_02" },
+		{ CardClass::WARLOCK, "HERO_07" },
+		{ CardClass::WARRIOR, "HERO_01" },
+	};
+
 	const std::map<const CardClass, const std::string> ConvertFromCardClassToHeroPowerID =
 	{
 		{ CardClass::DRUID, "CS2_017" },

--- a/Sources/Enums/EnumsToString.h
+++ b/Sources/Enums/EnumsToString.h
@@ -93,28 +93,28 @@ namespace Hearthstonepp
 
 	const std::map<const CardClass, const std::string> ConvertFromCardClassToHeroID =
 	{
-		{ CardClass::DRUID, "HERO_06" },
-		{ CardClass::HUNTER, "HERO_05" },
-		{ CardClass::MAGE, "HERO_08" },
-		{ CardClass::PALADIN, "HERO_04" },
-		{ CardClass::PRIEST, "HERO_09" },
-		{ CardClass::ROGUE, "HERO_03" },
-		{ CardClass::SHAMAN, "HERO_02" },
-		{ CardClass::WARLOCK, "HERO_07" },
-		{ CardClass::WARRIOR, "HERO_01" },
+		{ CardClass::DRUID,			"HERO_06" },
+		{ CardClass::HUNTER,		"HERO_05" },
+		{ CardClass::MAGE,			"HERO_08" },
+		{ CardClass::PALADIN,		"HERO_04" },
+		{ CardClass::PRIEST,		"HERO_09" },
+		{ CardClass::ROGUE,			"HERO_03" },
+		{ CardClass::SHAMAN,		"HERO_02" },
+		{ CardClass::WARLOCK,		"HERO_07" },
+		{ CardClass::WARRIOR,		"HERO_01" },
 	};
 
 	const std::map<const CardClass, const std::string> ConvertFromCardClassToHeroPowerID =
 	{
-		{ CardClass::DRUID, "CS2_017" },
-		{ CardClass::HUNTER, "DS1h_292" },
-		{ CardClass::MAGE, "CS2_034" },
-		{ CardClass::PALADIN, "CS2_101" },
-		{ CardClass::PRIEST, "CS1h_001" },
-		{ CardClass::ROGUE, "CS2_083b" },
-		{ CardClass::SHAMAN, "CS2_049" },
-		{ CardClass::WARLOCK, "CS2_056" },
-		{ CardClass::WARRIOR, "CS2_102" },
+		{ CardClass::DRUID,			"CS2_017" },
+		{ CardClass::HUNTER,		"DS1h_292" },
+		{ CardClass::MAGE,			"CS2_034" },
+		{ CardClass::PALADIN,		"CS2_101" },
+		{ CardClass::PRIEST,		"CS1h_001" },
+		{ CardClass::ROGUE,			"CS2_083b" },
+		{ CardClass::SHAMAN,		"CS2_049" },
+		{ CardClass::WARLOCK,		"CS2_056" },
+		{ CardClass::WARRIOR,		"CS2_102" },
 	};
 
 	const std::map<const CardType, const std::string> ConverterFromCardTypeToString =

--- a/Sources/Hearthstonepp.vcxproj
+++ b/Sources/Hearthstonepp.vcxproj
@@ -131,7 +131,8 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="Agents\GameAgent.cpp" />
-    <ClCompile Include="Agents\Interface.cpp" />
+    <ClCompile Include="Interface\InteractBuffer.cpp" />
+    <ClCompile Include="Interface\Interface.cpp" />
     <ClCompile Include="Loaders\CardLoader.cpp" />
     <ClCompile Include="Loaders\PlayerLoader.cpp" />
     <ClCompile Include="main.cpp" />
@@ -149,11 +150,12 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Agents\GameAgent.h" />
-    <ClInclude Include="Agents\Interface.h" />
     <ClInclude Include="Commons\Constants.h" />
     <ClInclude Include="Enums\EnumsToString.h" />
     <ClInclude Include="Enums\StringToEnums.h" />
     <ClInclude Include="Enums\Enums.h" />
+    <ClInclude Include="Interface\InteractBuffer.h" />
+    <ClInclude Include="Interface\Interface.h" />
     <ClInclude Include="Loaders\CardLoader.h" />
     <ClInclude Include="Loaders\PlayerLoader.h" />
     <ClInclude Include="Models\Card.h" />

--- a/Sources/Hearthstonepp.vcxproj
+++ b/Sources/Hearthstonepp.vcxproj
@@ -130,6 +130,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="Agents\AgentStructures.cpp" />
     <ClCompile Include="Agents\GameAgent.cpp" />
     <ClCompile Include="Interface\InteractBuffer.cpp" />
     <ClCompile Include="Interface\Interface.cpp" />
@@ -149,6 +150,7 @@
     <ClCompile Include="Programs\Console.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Agents\AgentStructures.h" />
     <ClInclude Include="Agents\GameAgent.h" />
     <ClInclude Include="Commons\Constants.h" />
     <ClInclude Include="Enums\EnumsToString.h" />

--- a/Sources/Hearthstonepp.vcxproj.filters
+++ b/Sources/Hearthstonepp.vcxproj.filters
@@ -76,6 +76,9 @@
     <ClCompile Include="Interface\Interface.cpp">
       <Filter>Interface</Filter>
     </ClCompile>
+    <ClCompile Include="Agents\AgentStructures.cpp">
+      <Filter>Agents</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Enums\Enums.h">
@@ -137,6 +140,9 @@
     </ClInclude>
     <ClInclude Include="Interface\Interface.h">
       <Filter>Interface</Filter>
+    </ClInclude>
+    <ClInclude Include="Agents\AgentStructures.h">
+      <Filter>Agents</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Sources/Hearthstonepp.vcxproj.filters
+++ b/Sources/Hearthstonepp.vcxproj.filters
@@ -22,6 +22,9 @@
     <Filter Include="Commons">
       <UniqueIdentifier>{f3f6e453-0524-4dda-b84c-80971ff51259}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Interface">
+      <UniqueIdentifier>{3f6465ae-6d35-49d5-bac1-4d15b37ba0b5}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />
@@ -32,9 +35,6 @@
       <Filter>Models</Filter>
     </ClCompile>
     <ClCompile Include="Agents\GameAgent.cpp">
-      <Filter>Agents</Filter>
-    </ClCompile>
-    <ClCompile Include="Agents\Interface.cpp">
       <Filter>Agents</Filter>
     </ClCompile>
     <ClCompile Include="Programs\Console.cpp">
@@ -69,6 +69,12 @@
     </ClCompile>
     <ClCompile Include="Loaders\PlayerLoader.cpp">
       <Filter>Loaders</Filter>
+    </ClCompile>
+    <ClCompile Include="Interface\InteractBuffer.cpp">
+      <Filter>Interface</Filter>
+    </ClCompile>
+    <ClCompile Include="Interface\Interface.cpp">
+      <Filter>Interface</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -105,9 +111,6 @@
     <ClInclude Include="Agents\GameAgent.h">
       <Filter>Agents</Filter>
     </ClInclude>
-    <ClInclude Include="Agents\Interface.h">
-      <Filter>Agents</Filter>
-    </ClInclude>
     <ClInclude Include="Programs\Console.h">
       <Filter>Programs</Filter>
     </ClInclude>
@@ -128,6 +131,12 @@
     </ClInclude>
     <ClInclude Include="Loaders\PlayerLoader.h">
       <Filter>Loaders</Filter>
+    </ClInclude>
+    <ClInclude Include="Interface\InteractBuffer.h">
+      <Filter>Interface</Filter>
+    </ClInclude>
+    <ClInclude Include="Interface\Interface.h">
+      <Filter>Interface</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Sources/Interface/InteractBuffer.cpp
+++ b/Sources/Interface/InteractBuffer.cpp
@@ -1,12 +1,12 @@
 /*************************************************************************
-> File Name: Interface.cpp
+> File Name: InteractBuffer.cpp
 > Project Name: Hearthstone++
 > Author: Young-Joong Kim
-> Purpose: Interface for Hearthstone Game Agent
+> Purpose: InteractBuffer for Hearthstone Game Agent
 > Created Time: 2017/10/04
 > Copyright (c) 2017, Young-Joong Kim
 *************************************************************************/
-#include <Agents/Interface.h>
+#include <Interface/InteractBuffer.h>
 
 namespace Hearthstonepp
 {

--- a/Sources/Interface/InteractBuffer.cpp
+++ b/Sources/Interface/InteractBuffer.cpp
@@ -11,8 +11,8 @@
 namespace Hearthstonepp
 {
 	InteractBuffer::InteractBuffer(int capacity)
+		: m_capacity(capacity)
 	{
-		m_capacity = capacity;
 		m_buffer = new BYTE[capacity]; // buffer, circular queue
 	}
 
@@ -21,7 +21,7 @@ namespace Hearthstonepp
 		return m_capacity;
 	}
 
-	int InteractBuffer::ReadBuffer(BYTE *data, int maxSize)
+	int InteractBuffer::ReadBuffer(BYTE* data, int maxSize)
 	{
 		std::unique_lock<std::mutex> lock(m_mtx);
 		m_cv.wait(lock, [this]() { return m_readable; }); // wait until the buffer can be read
@@ -44,12 +44,12 @@ namespace Hearthstonepp
 		return read;
 	}
 
-	int InteractBuffer::WriteBuffer(BYTE *data, int size)
+	int InteractBuffer::WriteBuffer(BYTE* data, int size)
 	{
 		std::unique_lock<std::mutex> lock(m_mtx);
 		m_cv.wait(lock, [this]() { return !m_readable; }); // wait until the buffer can be write
 
-		for (int i = 0; (i < size) && (m_usage < m_capacity); ++i) // write data to buffer
+		for (size_t i = 0; (i < size) && (m_usage < m_capacity); ++i) // write data to buffer
 		{
 			m_buffer[m_tail] = data[i];
 

--- a/Sources/Interface/InteractBuffer.cpp
+++ b/Sources/Interface/InteractBuffer.cpp
@@ -16,6 +16,11 @@ namespace Hearthstonepp
 		m_buffer = new BYTE[capacity]; // buffer, circular queue
 	}
 
+	int InteractBuffer::GetCapacity() const
+	{
+		return m_capacity;
+	}
+
 	int InteractBuffer::ReadBuffer(BYTE *data, int maxSize)
 	{
 		std::unique_lock<std::mutex> lock(m_mtx);

--- a/Sources/Interface/InteractBuffer.h
+++ b/Sources/Interface/InteractBuffer.h
@@ -21,6 +21,8 @@ namespace Hearthstonepp
 	public:
 		InteractBuffer(int capacity);
 
+		int GetCapacity() const;
+
 		int ReadBuffer(BYTE *data, int maxSize);
 		int WriteBuffer(BYTE *data, int size);
 

--- a/Sources/Interface/InteractBuffer.h
+++ b/Sources/Interface/InteractBuffer.h
@@ -1,13 +1,13 @@
 /*************************************************************************
-> File Name: Interface.h
+> File Name: InteractBuffer.h
 > Project Name: Hearthstone++
 > Author: Young-Joong Kim
-> Purpose: Interface for Hearthstone Game Agent
+> Purpose: InteractBuffer for Hearthstone Game Agent
 > Created Time: 2017/10/04
 > Copyright (c) 2017, Young-Joong Kim
 *************************************************************************/
-#ifndef HEARTHSTONEPP_INTERFACE_H
-#define HEARTHSTONEPP_INTERFACE_H
+#ifndef HEARTHSTONEPP_INTERACTBUFFER_H
+#define HEARTHSTONEPP_INTERACTBUFFER_H
 
 #include <condition_variable>
 #include <mutex>

--- a/Sources/Interface/InteractBuffer.h
+++ b/Sources/Interface/InteractBuffer.h
@@ -6,8 +6,8 @@
 > Created Time: 2017/10/04
 > Copyright (c) 2017, Young-Joong Kim
 *************************************************************************/
-#ifndef HEARTHSTONEPP_INTERACTBUFFER_H
-#define HEARTHSTONEPP_INTERACTBUFFER_H
+#ifndef HEARTHSTONEPP_INTERACT_BUFFER_H
+#define HEARTHSTONEPP_INTERACT_BUFFER_H
 
 #include <condition_variable>
 #include <mutex>
@@ -23,8 +23,8 @@ namespace Hearthstonepp
 
 		int GetCapacity() const;
 
-		int ReadBuffer(BYTE *data, int maxSize);
-		int WriteBuffer(BYTE *data, int size);
+		int ReadBuffer(BYTE* data, int maxSize);
+		int WriteBuffer(BYTE* data, int size);
 
 	private:
 		std::mutex m_mtx;
@@ -33,7 +33,7 @@ namespace Hearthstonepp
 		int m_capacity;
 		bool m_readable = false;
 
-		BYTE *m_buffer;
+		BYTE* m_buffer;
 		int m_head = 0;
 		int m_tail = 0;
 		int m_usage = 0;

--- a/Sources/Interface/Interface.cpp
+++ b/Sources/Interface/Interface.cpp
@@ -57,8 +57,9 @@ namespace Hearthstonepp
 	void GameInterface::BeginFirst()
 	{
 		BeginFirstStructure *data = (BeginFirstStructure*)m_buffer;
-		m_users[0] = *data->m_userFirst;
-		m_users[1] = *data->m_userLast;
+
+		m_users[0] = data->m_userFirst;
+		m_users[1] = data->m_userLast;
 
 		LogWriter(m_users[0], "Begin First");
 		LogWriter(m_users[1], "Begin Last");

--- a/Sources/Interface/Interface.cpp
+++ b/Sources/Interface/Interface.cpp
@@ -105,11 +105,11 @@ namespace Hearthstonepp
 		{
 			while (true)
 			{
-				BYTE index = 0;
-				std::cout << "[*] Input card index " << i+1 << " : ";
+				int index = 0;
+				std::cout << "[*] Input card index " << i+1 << " (0 ~ 2) : ";
 				std::cin >> index;
 
-				if (index >= 0 && index <= 3)
+				if (index >= 0 && index <= 2)
 				{
 					mulligan[i] = index;
 					break;

--- a/Sources/Interface/Interface.cpp
+++ b/Sources/Interface/Interface.cpp
@@ -1,0 +1,56 @@
+/*************************************************************************
+> File Name: Interface.cpp
+> Project Name: Hearthstone++
+> Author: Young-Joong Kim
+> Purpose: Interface for Hearthstone Game Agent
+> Created Time: 2017/10/24
+> Copyright (c) 2017, Young-Joong Kim
+*************************************************************************/
+#include <Interface/Interface.h>
+
+namespace Hearthstonepp
+{
+	GameInterface::GameInterface(GameAgent& agent)
+		: m_agent(agent)
+	{
+		// Do Nothing
+	}
+
+	GameResult GameInterface::StartGame()
+	{
+		GameResult result;
+		std::thread *at = m_agent.StartAgent(result);
+
+		for (int i = 0; i < 2; ++i)
+		{
+			Mulligan();
+		}
+
+		at->join(); // join agent thread
+
+		return result;
+	}
+
+	void GameInterface::Mulligan()
+	{
+		Card *list[3] = { 0, };
+		int result = m_agent.ReadBuffer((BYTE*)list, sizeof(Card*) * 3); // get card data
+
+		for (auto card : list)
+		{
+			std::cout << "[" << card->GetCardName() << "] ";
+		}
+		std::cout << std::endl;
+
+		BYTE mulligan[] = { 0, 2 }; // index of the card to be mulligan
+		result = m_agent.WriteBuffer(mulligan, 2); // send index to agent
+
+		result = m_agent.ReadBuffer((BYTE*)list, sizeof(Card*) * 3); // get new card data
+
+		for (auto card : list)
+		{
+			std::cout << "[" << card->GetCardName() << "] ";
+		}
+		std::cout << std::endl;
+	}
+}

--- a/Sources/Interface/Interface.cpp
+++ b/Sources/Interface/Interface.cpp
@@ -20,12 +20,12 @@ namespace Hearthstonepp
 	GameResult GameInterface::StartGame()
 	{
 		GameResult result;
-		std::thread *at = m_agent.StartAgent(result);
+		std::thread* at = m_agent.StartAgent(result);
 
 		while (true)
 		{
 			int result = HandleMessage();
-			if (result) break;
+			if (result == HANDLE_STOP) break;
 		}
 
 		at->join(); // join agent thread
@@ -39,14 +39,14 @@ namespace Hearthstonepp
 		m_agent.ReadBuffer(m_buffer, m_bufferCapacity);
 		if (m_buffer[0] == static_cast<BYTE>(Step::FINAL_GAMEOVER))
 		{
-			return 1;
+			return HANDLE_STOP;
 		}
 		else if (m_handler.find(m_buffer[0]) != m_handler.end())
 		{
 			m_handler[m_buffer[0]](*this);
 		}
 
-		return 0;
+		return HANDLE_CONTINUE;
 	}
 
 	void GameInterface::LogWriter(std::string& name, std::string message)
@@ -56,10 +56,10 @@ namespace Hearthstonepp
 
 	void GameInterface::BeginFirst()
 	{
-		BeginFirstStructure *data = (BeginFirstStructure*)m_buffer;
+		BeginFirstStructure* data = (BeginFirstStructure*)m_buffer;
 
-		m_users[0] = data->m_userFirst;
-		m_users[1] = data->m_userLast;
+		m_users[0] = data->userFirst;
+		m_users[1] = data->userLast;
 
 		LogWriter(m_users[0], "Begin First");
 		LogWriter(m_users[1], "Begin Last");
@@ -67,26 +67,26 @@ namespace Hearthstonepp
 
 	void GameInterface::BeginShuffle()
 	{
-		BeginShuffleStructure *data = (BeginShuffleStructure*)m_buffer;
-		LogWriter(m_users[data->m_userID], "Begin Shuffle");
+		BeginShuffleStructure* data = (BeginShuffleStructure*)m_buffer;
+		LogWriter(m_users[data->userID], "Begin Shuffle");
 	}
 
 	void GameInterface::BeginDraw()
 	{
-		DrawStructure *data = (DrawStructure*)m_buffer;
-		LogWriter(m_users[data->m_userID], "Begin Draw");
+		DrawStructure* data = (DrawStructure*)m_buffer;
+		LogWriter(m_users[data->userID], "Begin Draw");
 
-		for (int i = 0; i < 3; ++i)
+		for (int i = 0; i < NUM_BEGIN_DRAW; ++i)
 		{
-			std::cout << "[" << data->m_cards[i]->GetCardName() << "] ";
+			std::cout << "[" << data->cards[i]->GetCardName() << "] ";
 		}
 		std::cout << std::endl;
 	}
 
 	void GameInterface::BeginMulligan()
 	{
-		BeginMulliganStructure *data = (BeginMulliganStructure*)m_buffer;
-		LogWriter(m_users[data->m_userID], "Begin Mulligan");
+		BeginMulliganStructure* data = (BeginMulliganStructure*)m_buffer;
+		LogWriter(m_users[data->userID], "Begin Mulligan");
 
 		int numMulligan;
 		while (true)
@@ -94,13 +94,13 @@ namespace Hearthstonepp
 			std::cout << "[*] How many cards to mulligan ? (0 ~ 3) ";
 			std::cin >> numMulligan;
 
-			if (numMulligan >= 0 && numMulligan <= 3)
+			if (numMulligan >= 0 && numMulligan <= NUM_BEGIN_DRAW)
 			{
 				break;
 			}
 		}
 
-		BYTE mulligan[3] = { 0, };
+		BYTE mulligan[NUM_BEGIN_DRAW] = { 0, };
 		for (int i = 0; i < numMulligan; ++i)
 		{
 			while (true)
@@ -109,7 +109,7 @@ namespace Hearthstonepp
 				std::cout << "[*] Input card index " << i+1 << " (0 ~ 2) : ";
 				std::cin >> index;
 
-				if (index >= 0 && index <= 2)
+				if (index >= 0 && index <= NUM_BEGIN_DRAW - 1)
 				{
 					mulligan[i] = index;
 					break;
@@ -120,12 +120,12 @@ namespace Hearthstonepp
 		m_agent.WriteBuffer(mulligan, numMulligan); // send index to agent
 		m_agent.ReadBuffer(m_buffer, sizeof(DrawStructure)); // get new card data
 		
-		LogWriter(m_users[data->m_userID], "Mulligan Result");
+		LogWriter(m_users[data->userID], "Mulligan Result");
 
-		DrawStructure *draw = (DrawStructure*)m_buffer;
-		for (int i = 0; i < 3; ++i)
+		DrawStructure* draw = (DrawStructure*)m_buffer;
+		for (int i = 0; i < NUM_BEGIN_DRAW; ++i)
 		{
-			std::cout << "[" << draw->m_cards[i]->GetCardName() << "] ";
+			std::cout << "[" << draw->cards[i]->GetCardName() << "] ";
 		}
 		std::cout << std::endl;
 	}

--- a/Sources/Interface/Interface.h
+++ b/Sources/Interface/Interface.h
@@ -11,7 +11,9 @@
 
 #include <Agents/GameAgent.h>
 
+#include <functional>
 #include <iostream>
+#include <map>
 
 namespace Hearthstonepp
 {
@@ -22,9 +24,27 @@ namespace Hearthstonepp
 		GameResult StartGame();
 
 	private:
-		GameAgent& m_agent;
+		int HandleMessage();
+		void LogWriter(std::string& name, std::string meesage);
 
-		void Mulligan();
+		void BeginFirst();
+		void BeginShuffle();
+		void BeginDraw();
+		void BeginMulligan();
+
+		GameAgent& m_agent;
+		std::string m_users[2];
+
+		BYTE *m_buffer;
+		int m_bufferCapacity;
+
+		std::map<BYTE, std::function<void(GameInterface&)>> m_handler =
+		{
+			{ static_cast<BYTE>(Step::BEGIN_FIRST), &GameInterface::BeginFirst },
+			{ static_cast<BYTE>(Step::BEGIN_SHUFFLE), &GameInterface::BeginShuffle },
+			{ static_cast<BYTE>(Step::BEGIN_DRAW), &GameInterface::BeginDraw },
+			{ static_cast<BYTE>(Step::BEGIN_MULLIGAN), &GameInterface::BeginMulligan }
+		};
 	};
 }
 

--- a/Sources/Interface/Interface.h
+++ b/Sources/Interface/Interface.h
@@ -1,0 +1,31 @@
+/*************************************************************************
+> File Name: Interface.h
+> Project Name: Hearthstone++
+> Author: Young-Joong Kim
+> Purpose: Interface for Hearthstone Game Agent
+> Created Time: 2017/10/24
+> Copyright (c) 2017, Young-Joong Kim
+*************************************************************************/
+#ifndef HEARTHSTONEPP_INTERFACE_H
+#define HEARTHSTONEPP_INTERFACE_H
+
+#include <Agents/GameAgent.h>
+
+#include <iostream>
+
+namespace Hearthstonepp
+{
+	class GameInterface
+	{
+	public:
+		GameInterface(GameAgent& agent);
+		GameResult StartGame();
+
+	private:
+		GameAgent& m_agent;
+
+		void Mulligan();
+	};
+}
+
+#endif

--- a/Sources/Interface/Interface.h
+++ b/Sources/Interface/Interface.h
@@ -10,6 +10,7 @@
 #define HEARTHSTONEPP_INTERFACE_H
 
 #include <Agents/GameAgent.h>
+#include <Commons/Constants.h>
 
 #include <functional>
 #include <iostream>
@@ -35,8 +36,11 @@ namespace Hearthstonepp
 		GameAgent& m_agent;
 		std::string m_users[2];
 
-		BYTE *m_buffer;
+		BYTE* m_buffer;
 		int m_bufferCapacity;
+
+		const unsigned int HANDLE_CONTINUE = 0;
+		const unsigned int HANDLE_STOP = 1;
 
 		std::map<BYTE, std::function<void(GameInterface&)>> m_handler =
 		{

--- a/Sources/Models/Card.cpp
+++ b/Sources/Models/Card.cpp
@@ -37,6 +37,16 @@ namespace Hearthstonepp
 		return m_id;
 	}
 
+	std::string Card::GetCardName() const
+	{
+		return m_name;
+	}
+
+	CardType Card::GetCardType() const
+	{
+		return m_cardType;
+	}
+
 	CardClass Card::GetCardClass() const
 	{
 		return m_cardClass;

--- a/Sources/Models/Card.h
+++ b/Sources/Models/Card.h
@@ -31,6 +31,8 @@ namespace Hearthstonepp
 		virtual ~Card() = default;
 
 		std::string GetID() const;
+		std::string GetCardName() const;
+		CardType GetCardType() const;
 		CardClass GetCardClass() const;
 		unsigned int GetMaxAllowedInDeck() const;
 

--- a/Sources/Models/Deck.cpp
+++ b/Sources/Models/Deck.cpp
@@ -57,6 +57,23 @@ namespace Hearthstonepp
 		return 0;
 	}
 
+	std::vector<Card*> Deck::GetPrimitiveDeck() const
+	{
+		Cards *cards = Cards::GetInstance();
+
+		std::vector<Card*> deck;
+		for (auto& pair : m_cards)
+		{
+			Card *card = const_cast<Card*>(cards->FindCardByID(pair.first));
+			for (int i = 0; i < pair.second; ++i)
+			{
+				deck.push_back(card);
+			}	
+		}
+
+		return deck;
+	}
+
 	std::pair<std::string, int> Deck::GetCard(size_t idx) const
 	{
 		return m_cards.at(idx);

--- a/Sources/Models/Deck.cpp
+++ b/Sources/Models/Deck.cpp
@@ -59,12 +59,12 @@ namespace Hearthstonepp
 
 	std::vector<Card*> Deck::GetPrimitiveDeck() const
 	{
-		Cards *cards = Cards::GetInstance();
+		Cards* cards = Cards::GetInstance();
 
 		std::vector<Card*> deck;
 		for (auto& pair : m_cards)
 		{
-			Card *card = const_cast<Card*>(cards->FindCardByID(pair.first));
+			Card* card = const_cast<Card*>(cards->FindCardByID(pair.first));
 			for (int i = 0; i < pair.second; ++i)
 			{
 				deck.push_back(card);

--- a/Sources/Models/Deck.h
+++ b/Sources/Models/Deck.h
@@ -11,6 +11,7 @@
 
 #include <Enums/Enums.h>
 #include <Models/Card.h>
+#include <Models/Cards.h>
 
 #include <string>
 
@@ -27,6 +28,7 @@ namespace Hearthstonepp
 		unsigned int GetNumOfCards() const;
 		size_t GetUniqueNumOfCards() const;
 		unsigned int GetNumCardInDeck(std::string cardID);
+		std::vector<Card*> GetPrimitiveDeck() const;
 		std::pair<std::string, int> GetCard(size_t idx) const;
 
 		void AddCard(std::string cardID, int numCardToAdd);

--- a/Sources/Programs/Console.cpp
+++ b/Sources/Programs/Console.cpp
@@ -175,8 +175,8 @@ namespace Hearthstonepp
 		std::cin >> user2 >> deck2;
 
 		PlayerLoader loader;
-		Player *p1 = loader.Load(user1);
-		Player *p2 = loader.Load(user2);
+		Player* p1 = loader.Load(user1);
+		Player* p2 = loader.Load(user2);
 
 		GameAgent agent(User(p1, deck1), User(p2, deck2));
 		GameInterface game(agent);

--- a/Sources/Programs/Console.cpp
+++ b/Sources/Programs/Console.cpp
@@ -9,6 +9,7 @@
 #include <Agents/GameAgent.h>
 #include <Commons/Constants.h>
 #include <Enums/EnumsToString.h>
+#include <Interface/Interface.h>
 #include <Loaders/CardLoader.h>
 #include <Loaders/PlayerLoader.h>
 #include <Models/Card.h>
@@ -168,35 +169,10 @@ namespace Hearthstonepp
 		Player *p1 = loader.Load("temp1");
 		Player *p2 = loader.Load("temp2");
 
-		GameResult result;
 		GameAgent agent(User(p1, 0), User(p2, 0));
+		GameInterface game(agent);
 
-		std::thread *at = agent.StartAgent(result);
-
-		for (int i = 0; i < 2; ++i)
-		{
-			Card *list[3] = { 0, };
-			int result = agent.ReadBuffer((BYTE*)list, sizeof(Card*) * 3); // get card data
-
-			for (auto card : list)
-			{
-				std::cout << "[" << card->GetCardName() << "] ";
-			}
-			std::cout << std::endl;
-
-			BYTE mulligan[] = { 0, 2 }; // index of the card to be mulligan
-			result = agent.WriteBuffer(mulligan, 2); // send index to agent
-
-			result = agent.ReadBuffer((BYTE*)list, sizeof(Card*) * 3); // get new card data
-
-			for (auto card : list)
-			{
-				std::cout << "[" << card->GetCardName() << "] ";
-			}
-			std::cout << std::endl;
-		}
-
-		at->join(); // join agent thread
+		GameResult result = game.StartGame();
 	}
 
 	void Console::Leave()

--- a/Sources/Programs/Console.cpp
+++ b/Sources/Programs/Console.cpp
@@ -165,11 +165,20 @@ namespace Hearthstonepp
 
 	void Console::SimulateGame()
 	{
-		PlayerLoader loader;
-		Player *p1 = loader.Load("temp1");
-		Player *p2 = loader.Load("temp2");
+		int deck1, deck2;
+		std::string user1, user2;
 
-		GameAgent agent(User(p1, 0), User(p2, 0));
+		std::cout << "[*] input first id, deck index : ";
+		std::cin >> user1 >> deck1;
+
+		std::cout << "[*] input second id, deck index : ";
+		std::cin >> user2 >> deck2;
+
+		PlayerLoader loader;
+		Player *p1 = loader.Load(user1);
+		Player *p2 = loader.Load(user2);
+
+		GameAgent agent(User(p1, deck1), User(p2, deck2));
 		GameInterface game(agent);
 
 		GameResult result = game.StartGame();

--- a/Sources/Programs/Console.cpp
+++ b/Sources/Programs/Console.cpp
@@ -164,52 +164,39 @@ namespace Hearthstonepp
 
 	void Console::SimulateGame()
 	{
-		//CardLoader loader;
-		//std::vector<Card*> cards;
+		PlayerLoader loader;
+		Player *p1 = loader.Load("temp1");
+		Player *p2 = loader.Load("temp2");
 
-		//loader.Load(cards);
+		GameResult result;
+		GameAgent agent(User(p1, 0), User(p2, 0));
 
-		//Deck deck1; // temporal deck
-		//Deck deck2;
+		std::thread *at = agent.StartAgent(result);
 
-		//deck1.reserve(30);
-		//deck2.reserve(30);
+		for (int i = 0; i < 2; ++i)
+		{
+			Card *list[3] = { 0, };
+			int result = agent.ReadBuffer((BYTE*)list, sizeof(Card*) * 3); // get card data
 
-		//deck1.assign(cards.begin(), cards.begin() + 30); 
-		//deck2.assign(cards.begin() + 30, cards.begin() + 60);
+			for (auto card : list)
+			{
+				std::cout << "[" << card->GetCardName() << "] ";
+			}
+			std::cout << std::endl;
 
-		//User user1(0, new Hero(), new HeroPower(), deck1); // define new user
-		//User user2(1, new Hero(), new HeroPower(), deck2);
+			BYTE mulligan[] = { 0, 2 }; // index of the card to be mulligan
+			result = agent.WriteBuffer(mulligan, 2); // send index to agent
 
-		//GameAgent agent(&user1, &user2);
-		//GameResult result;
+			result = agent.ReadBuffer((BYTE*)list, sizeof(Card*) * 3); // get new card data
 
-		//std::thread *at = agent.StartAgent(result);
+			for (auto card : list)
+			{
+				std::cout << "[" << card->GetCardName() << "] ";
+			}
+			std::cout << std::endl;
+		}
 
-		//for (int i = 0; i < 2; ++i)
-		//{
-		//	Card *list[3] = { 0, };
-		//	int result = agent.ReadBuffer((BYTE*)list, sizeof(Card*) * 3); // get card data
-
-		//	for (auto card : list)
-		//	{
-		//		std::cout << "[" << card->name << "] ";
-		//	}
-		//	std::cout << std::endl;
-
-		//	BYTE mulligan[] = { 0, 2 }; // index of the card to be mulligan
-		//	result = agent.WriteBuffer(mulligan, 2); // send index to agent
-
-		//	result = agent.ReadBuffer((BYTE*)list, sizeof(Card*) * 3); // get new card data
-
-		//	for (auto card : list)
-		//	{
-		//		std::cout << "[" << card->name << "] ";
-		//	}
-		//	std::cout << std::endl;
-		//}
-
-		//at->join(); // join agent thread
+		at->join(); // join agent thread
 	}
 
 	void Console::Leave()


### PR DESCRIPTION
새로운 덱 시스템과 플레이어 시스템에 맞게 게임 에이전트를 개편하였습니다.
콘솔의 SimulateGame과 게임 인터페이스를 분리하기 위해 GameInterface 클래스를 추가로 구현하였습니다.
GameInterface와 GameAgent의 원활한 소통을 위해 AgentStructure에 관련 구조체를 정의하였습니다.
이로써, 메인 에이전트 개발 전 준비 과정을 모두 마친듯 합니다. 