### PR TITLE
Implement basic card search system, Part 2 - Connect card search functions to add card in deck function, add brief card info method and search mode, fix some bugs (#15)

### DIFF
--- a/Sources/Interface/Interface.h
+++ b/Sources/Interface/Interface.h
@@ -43,10 +43,10 @@ namespace Hearthstonepp
 
 		std::map<BYTE, std::function<void(GameInterface&)>> m_handler =
 		{
-			{ static_cast<BYTE>(Step::BEGIN_FIRST), &GameInterface::BeginFirst },
-			{ static_cast<BYTE>(Step::BEGIN_SHUFFLE), &GameInterface::BeginShuffle },
-			{ static_cast<BYTE>(Step::BEGIN_DRAW), &GameInterface::BeginDraw },
-			{ static_cast<BYTE>(Step::BEGIN_MULLIGAN), &GameInterface::BeginMulligan }
+			{ static_cast<BYTE>(Step::BEGIN_FIRST),		&GameInterface::BeginFirst },
+			{ static_cast<BYTE>(Step::BEGIN_SHUFFLE),	&GameInterface::BeginShuffle },
+			{ static_cast<BYTE>(Step::BEGIN_DRAW),		&GameInterface::BeginDraw },
+			{ static_cast<BYTE>(Step::BEGIN_MULLIGAN),	&GameInterface::BeginMulligan }
 		};
 	};
 }

--- a/Sources/Loaders/PlayerLoader.cpp
+++ b/Sources/Loaders/PlayerLoader.cpp
@@ -100,7 +100,7 @@ namespace Hearthstonepp
 					{ "cards", json::array() }
 				}));
 
-				for (size_t cardIdx = 0; cardIdx < p->GetDeck(deckIdx)->GetNumOfCards(); ++cardIdx)
+				for (size_t cardIdx = 0; cardIdx < p->GetDeck(deckIdx)->GetUniqueNumOfCards(); ++cardIdx)
 				{
 					j["decks"].at(deckIdx)["cards"].emplace_back(json::object({
 						{ "id", p->GetDeck(deckIdx)->GetCard(cardIdx).first },

--- a/Sources/Models/Card.cpp
+++ b/Sources/Models/Card.cpp
@@ -102,6 +102,11 @@ namespace Hearthstonepp
 		return m_maxAllowedInDeck;
 	}
 
+	void Card::ShowBriefInfo() const
+	{
+		std::cout << m_name.c_str() << " (" << m_id.c_str() << ")\n";
+	}
+
 	void Card::ShowInfo() const
 	{
 		std::cout << "========================================\n";

--- a/Sources/Models/Card.cpp
+++ b/Sources/Models/Card.cpp
@@ -109,7 +109,7 @@ namespace Hearthstonepp
 
 	void Card::ShowBriefInfo() const
 	{
-		std::cout << m_name.c_str() << " (" << m_id.c_str() << ")\n";
+		std::cout << m_name.c_str() << " (" << m_id.c_str() << ") ";
 	}
 
 	void Card::ShowInfo() const

--- a/Sources/Models/Card.cpp
+++ b/Sources/Models/Card.cpp
@@ -62,6 +62,11 @@ namespace Hearthstonepp
 		return m_name;
 	}
 
+	bool Card::GetCollectible() const
+	{
+		return m_collectible;
+	}
+
 	int Card::GetCost() const
 	{
 		return m_cost;

--- a/Sources/Models/Card.cpp
+++ b/Sources/Models/Card.cpp
@@ -109,9 +109,6 @@ namespace Hearthstonepp
 
 	void Card::ShowInfo() const
 	{
-		std::cout << "========================================\n";
-		std::cout << "               Card Info!               \n";
-		std::cout << "========================================\n";
 		std::cout << "ID: " << m_id.c_str() << '\n';
 		std::cout << "Name: " << m_name.c_str() << '\n';
 		std::cout << "Text: " << m_text.c_str() << '\n';

--- a/Sources/Models/Card.h
+++ b/Sources/Models/Card.h
@@ -36,6 +36,7 @@ namespace Hearthstonepp
 		CardType GetCardType() const;
 		Race GetRace() const;
 		std::string GetName() const;
+		bool GetCollectible() const;
 		int GetCost() const;
 		int GetAttack() const;
 		int GetHealth() const;

--- a/Sources/Models/Card.h
+++ b/Sources/Models/Card.h
@@ -45,6 +45,7 @@ namespace Hearthstonepp
 
 		unsigned int GetMaxAllowedInDeck() const;
 
+		virtual void ShowBriefInfo() const;
 		virtual void ShowInfo() const;
 
 	private:

--- a/Sources/Models/Deck.cpp
+++ b/Sources/Models/Deck.cpp
@@ -9,6 +9,7 @@
 #include <Models/Deck.h>
 
 #include <algorithm>
+#include <iostream>
 
 namespace Hearthstonepp
 {
@@ -77,6 +78,27 @@ namespace Hearthstonepp
 	std::pair<std::string, int> Deck::GetCard(size_t idx) const
 	{
 		return m_cards.at(idx);
+	}
+
+	void Deck::ShowCardList() const
+	{
+		int idx = 1;
+
+		for (auto& cardInfo : m_cards)
+		{
+			const Card* card = Cards::GetInstance()->FindCardByID(cardInfo.first);
+			if (card == nullptr)
+			{
+				continue;
+			}
+
+			std::cout << idx << ". ";
+			card->ShowBriefInfo();
+			std::cout << "(" << cardInfo.second << " card(s))\n";
+			
+			idx++;
+		}
+
 	}
 
 	void Deck::AddCard(std::string cardID, int numCardToAdd)

--- a/Sources/Models/Deck.h
+++ b/Sources/Models/Deck.h
@@ -31,6 +31,8 @@ namespace Hearthstonepp
 		std::vector<Card*> GetPrimitiveDeck() const;
 		std::pair<std::string, int> GetCard(size_t idx) const;
 
+		void ShowCardList() const;
+
 		void AddCard(std::string cardID, int numCardToAdd);
 		void DeleteCard(std::string cardID, const int numCardToDelete);
 

--- a/Sources/Programs/Console.cpp
+++ b/Sources/Programs/Console.cpp
@@ -121,11 +121,23 @@ namespace Hearthstonepp
 				break;
 			}
 
+			std::cout << "========================================\n";
+			std::cout << "             Search Result!             \n";
+			std::cout << "========================================\n";
+			size_t idx = 1;
 			std::vector<Card*> result = ProcessSearchCommand(filter);
-
-			for (auto& card : result)
+			if (result.empty())
 			{
-				std::cout << card->GetName() << '\n';
+				std::cout << "There are no cards matching your search condition.\n";
+			}
+			else
+			{
+				for (auto& card : result)
+				{
+					std::cout << idx << ". ";
+					card->ShowBriefInfo();
+					idx++;
+				}
 			}
 		}
 	}
@@ -639,7 +651,7 @@ namespace Hearthstonepp
 		return std::make_tuple(filter, isValid, isFinish);
 	}
 
-	std::vector<Card*> Console::ProcessSearchCommand(SearchFilter filter)
+	std::vector<Card*> Console::ProcessSearchCommand(SearchFilter filter) const
 	{
 		std::vector<Card*> result;
 

--- a/Sources/Programs/Console.cpp
+++ b/Sources/Programs/Console.cpp
@@ -136,7 +136,15 @@ namespace Hearthstonepp
 				{
 					std::cout << idx << ". ";
 					card->ShowBriefInfo();
+					std::cout << '\n';
+
 					idx++;
+				}
+
+				if (m_searchMode == SearchMode::AddCardInDeck)
+				{
+					const size_t selectedCardIndex = InputMenuNum("Select: ", idx);
+					return result.at(selectedCardIndex);
 				}
 			}
 		}

--- a/Sources/Programs/Console.cpp
+++ b/Sources/Programs/Console.cpp
@@ -657,6 +657,11 @@ namespace Hearthstonepp
 
 		for (auto& card : Cards::GetInstance()->GetAllCards())
 		{
+			if (card->GetCollectible() == false)
+			{
+				continue;
+			}
+
 			bool rarityCondition = (filter.rarity == Rarity::INVALID || filter.rarity == card->GetRarity());
 			bool classCondition = (filter.playerClass == CardClass::INVALID || filter.playerClass == card->GetCardClass());
 			bool typeCondition = (filter.cardType == CardType::INVALID || filter.cardType == card->GetCardType());

--- a/Sources/Programs/Console.cpp
+++ b/Sources/Programs/Console.cpp
@@ -298,6 +298,7 @@ namespace Hearthstonepp
 
 		// Set flag that the card should be returned.
 		m_searchMode = SearchMode::AddCardInDeck;
+		m_deckClass = deck->GetClass();
 
 		const Card* card = SearchCard().value_or(nullptr);
 		if (card == nullptr)
@@ -390,6 +391,7 @@ namespace Hearthstonepp
 
 		// Set flag that you do not need to return the card.
 		m_searchMode = SearchMode::JustSearch;
+		m_deckClass = CardClass::INVALID;
 
 		m_mainMenuFuncs[selectedNum - 1](*this);
 
@@ -657,7 +659,16 @@ namespace Hearthstonepp
 			}
 
 			bool rarityCondition = (filter.rarity == Rarity::INVALID || filter.rarity == card->GetRarity());
-			bool classCondition = (filter.playerClass == CardClass::INVALID || filter.playerClass == card->GetCardClass());
+			bool classCondition;
+			// When search mode is adding a card to a deck, the class is fixed to the deck class and the neutral class.
+			if (m_searchMode == SearchMode::AddCardInDeck)
+			{
+				classCondition = (card->GetCardClass() == CardClass::NEUTRAL || card->GetCardClass() == m_deckClass);
+			}
+			else if (m_searchMode == SearchMode::JustSearch)
+			{
+				classCondition = (filter.playerClass == CardClass::INVALID || filter.playerClass == card->GetCardClass());
+			}
 			bool typeCondition = (filter.cardType == CardType::INVALID || filter.cardType == card->GetCardType());
 			bool raceCondition = (filter.race == Race::INVALID || filter.race == card->GetRace());
 			bool nameCondition = (filter.name.empty() || card->GetName().find(filter.name) != std::string::npos);

--- a/Sources/Programs/Console.cpp
+++ b/Sources/Programs/Console.cpp
@@ -96,7 +96,7 @@ namespace Hearthstonepp
 		}
 	}
 
-	void Console::SearchCard()
+	std::optional<Card*> Console::SearchCard()
 	{
 		std::cout << "========================================\n";
 		std::cout << "              Search Card!              \n";
@@ -140,6 +140,8 @@ namespace Hearthstonepp
 				}
 			}
 		}
+
+		return {};
 	}
 
 	int Console::ManageDeck()

--- a/Sources/Programs/Console.cpp
+++ b/Sources/Programs/Console.cpp
@@ -342,7 +342,7 @@ namespace Hearthstonepp
 
 		deck->ShowCardList();
 		const size_t selectedCardIndex = InputMenuNum("Select: ", deck->GetUniqueNumOfCards());
-		const std::string selectedCardID = deck->GetCard(selectedCardIndex).first;
+		const std::string selectedCardID = deck->GetCard(selectedCardIndex - 1).first;
 
 		while (true)
 		{

--- a/Sources/Programs/Console.cpp
+++ b/Sources/Programs/Console.cpp
@@ -260,35 +260,48 @@ namespace Hearthstonepp
 		m_player->DeleteDeck(selectedDeck);
 	}
 
-	void Console::OperateDeck(size_t selectedDeck)
+	int Console::OperateDeck(size_t deckIndex)
 	{
-		// Set flag that the card should be returned.
-		m_searchMode = SearchMode::AddCardInDeck;
+		ShowMenu(m_deckOperationStr);
+		const size_t selectedOperation = InputMenuNum("What do you want to do? ", CREATE_DECK_MENU_SIZE);
+		bool isFinish = false;
 
-		Deck* deck = m_player->GetDeck(selectedDeck - 1);
-		const CardClass deckClass = deck->GetClass();
-
-		while (true)
+		if (selectedOperation != CREATE_DECK_MENU_SIZE)
 		{
-			const Card* card = SearchCard().value_or(nullptr);
-			if (card == nullptr)
-			{
-				std::cout << " doesn't exist. Try again.\n";
-			}
+			m_deckOperationFuncs[selectedOperation - 1](*this, deckIndex);
 		}
+		else
+		{
+			isFinish = true;
+		}
+
+		return isFinish ? 0 : OperateDeck(deckIndex);
 	}
 
-	void Console::AddCardInDeck(Deck* deck, std::string& selectedCardID)
+	void Console::AddCardInDeck(size_t deckIndex)
 	{
+		Deck* deck = m_player->GetDeck(deckIndex - 1);
+		const CardClass deckClass = deck->GetClass();
+
 		if (deck->GetNumOfCards() >= MAXIMUM_NUM_CARDS_IN_DECK)
 		{
 			std::cout << "The deck " << deck->GetName() << " is full of cards.\n";
 			return;
 		}
 
+		// Set flag that the card should be returned.
+		m_searchMode = SearchMode::AddCardInDeck;
+
+		const Card* card = SearchCard().value_or(nullptr);
+		if (card == nullptr)
+		{
+			std::cout << " doesn't exist. Try again.\n";
+			return;
+		}
+
 		while (true)
 		{
-			unsigned int numCardToAddAvailable = Cards::GetInstance()->FindCardByID(selectedCardID)->GetMaxAllowedInDeck() - deck->GetNumCardInDeck(selectedCardID);
+			unsigned int numCardToAddAvailable = card->GetMaxAllowedInDeck() - deck->GetNumCardInDeck(card->GetID());
 			if (deck->GetNumOfCards() + numCardToAddAvailable > MAXIMUM_NUM_CARDS_IN_DECK)
 			{
 				numCardToAddAvailable = deck->GetNumOfCards() + numCardToAddAvailable - MAXIMUM_NUM_CARDS_IN_DECK;
@@ -304,15 +317,15 @@ namespace Hearthstonepp
 			}
 			else
 			{
-				deck->AddCard(selectedCardID, numCardToAdd);
+				deck->AddCard(card->GetID(), numCardToAdd);
 				break;
 			}
 		}
 	}
 
-	void Console::DeleteCardInDeck(Deck* deck, std::string& selectedCardID)
+	void Console::DeleteCardInDeck(size_t deckIndex)
 	{
-		if (deck->GetNumCardInDeck(selectedCardID) == 0)
+		/*if (deck->GetNumCardInDeck(selectedCardID) == 0)
 		{
 			std::cout << selectedCardID << " doesn't exist.\n";
 			return;
@@ -333,7 +346,7 @@ namespace Hearthstonepp
 				deck->DeleteCard(selectedCardID, numCardToDelete);
 				break;
 			}
-		}
+		}*/
 	}
 
 	int Console::Login()

--- a/Sources/Programs/Console.cpp
+++ b/Sources/Programs/Console.cpp
@@ -512,18 +512,18 @@ namespace Hearthstonepp
 		// Parse options
 		static struct option longOptions[] =
 		{
-			{ "rarity",		required_argument, nullptr, 'r' },
-			{ "class",		required_argument, nullptr, 'c' },
-			{ "type",       required_argument, nullptr, 't' },
-			{ "race",		required_argument, nullptr, 'e' },
-			{ "name",		required_argument, nullptr, 'n' },
-			{ "cost",		required_argument, nullptr, 's' },
-			{ "attack",		required_argument, nullptr, 'a' },
-			{ "health",		required_argument, nullptr, 'h' },
-			{ "mechanics",	required_argument, nullptr, 'm' },
-			{ "help",		no_argument,	   nullptr, 'p' },
-			{ "exit",		no_argument,	   nullptr, 'x' },
-			{ nullptr,		0,                 nullptr,  0 }
+			{ "rarity",		required_argument,	nullptr, 'r' },
+			{ "class",		required_argument,	nullptr, 'c' },
+			{ "type",		required_argument,	nullptr, 't' },
+			{ "race",		required_argument,	nullptr, 'e' },
+			{ "name",		required_argument,	nullptr, 'n' },
+			{ "cost",		required_argument,	nullptr, 's' },
+			{ "attack",		required_argument,	nullptr, 'a' },
+			{ "health",		required_argument,	nullptr, 'h' },
+			{ "mechanics",	required_argument,	nullptr, 'm' },
+			{ "help",		no_argument,		nullptr, 'p' },
+			{ "exit",		no_argument,		nullptr, 'x' },
+			{ nullptr,		0,					nullptr,  0 }
 		};
 
 		// Initialize opt index

--- a/Sources/Programs/Console.cpp
+++ b/Sources/Programs/Console.cpp
@@ -281,7 +281,6 @@ namespace Hearthstonepp
 	void Console::AddCardInDeck(size_t deckIndex)
 	{
 		Deck* deck = m_player->GetDeck(deckIndex - 1);
-		const CardClass deckClass = deck->GetClass();
 
 		if (deck->GetNumOfCards() >= MAXIMUM_NUM_CARDS_IN_DECK)
 		{
@@ -325,11 +324,17 @@ namespace Hearthstonepp
 
 	void Console::DeleteCardInDeck(size_t deckIndex)
 	{
-		/*if (deck->GetNumCardInDeck(selectedCardID) == 0)
+		Deck* deck = m_player->GetDeck(deckIndex - 1);
+
+		if (deck->GetNumOfCards() == 0)
 		{
-			std::cout << selectedCardID << " doesn't exist.\n";
+			std::cout << "The deck " << deck->GetName() << " is empty.\n";
 			return;
 		}
+
+		deck->ShowCardList();
+		const size_t selectedCardIndex = InputMenuNum("Select: ", deck->GetUniqueNumOfCards());
+		const std::string selectedCardID = deck->GetCard(selectedCardIndex).first;
 
 		while (true)
 		{
@@ -346,7 +351,7 @@ namespace Hearthstonepp
 				deck->DeleteCard(selectedCardID, numCardToDelete);
 				break;
 			}
-		}*/
+		}
 	}
 
 	int Console::Login()

--- a/Sources/Programs/Console.cpp
+++ b/Sources/Programs/Console.cpp
@@ -663,7 +663,14 @@ namespace Hearthstonepp
 			// When search mode is adding a card to a deck, the class is fixed to the deck class and the neutral class.
 			if (m_searchMode == SearchMode::AddCardInDeck)
 			{
-				classCondition = (card->GetCardClass() == CardClass::NEUTRAL || card->GetCardClass() == m_deckClass);
+				if (filter.playerClass == CardClass::NEUTRAL || filter.playerClass == m_deckClass)
+				{
+					classCondition = filter.playerClass == card->GetCardClass();
+				}
+				else
+				{
+					classCondition = (card->GetCardClass() == CardClass::NEUTRAL || card->GetCardClass() == m_deckClass);
+				}
 			}
 			else if (m_searchMode == SearchMode::JustSearch)
 			{

--- a/Sources/Programs/Console.cpp
+++ b/Sources/Programs/Console.cpp
@@ -262,55 +262,18 @@ namespace Hearthstonepp
 
 	void Console::OperateDeck(size_t selectedDeck)
 	{
+		// Set flag that the card should be returned.
+		m_searchMode = SearchMode::AddCardInDeck;
+
 		Deck* deck = m_player->GetDeck(selectedDeck - 1);
 		const CardClass deckClass = deck->GetClass();
 
-		std::cout << "Input Card ID to add or delete to your deck.\n";
-		std::cout << "If you do not want to add or delete more, please input \"STOP\"\n";
-
 		while (true)
 		{
-			std::cout << "The number of cards in the current deck = " << deck->GetNumOfCards() << " / " << MAXIMUM_NUM_CARDS_IN_DECK << "\n";
-			std::cout << "Card ID: ";
-			std::string selectedCardID;
-			std::cin >> selectedCardID;
-
-			if (selectedCardID == "STOP")
-			{
-				break;
-			}
-
-			const Card* card = Cards::GetInstance()->FindCardByID(selectedCardID);
+			const Card* card = SearchCard().value_or(nullptr);
 			if (card == nullptr)
 			{
-				std::cout << selectedCardID << " doesn't exist. Try again.\n";
-				continue;
-			}
-			if (card->GetCardClass() != CardClass::NEUTRAL && card->GetCardClass() != deckClass)
-			{
-				std::cout << "The class of " << selectedCardID << " is " << ConverterFromCardClassToString.at(card->GetCardClass()).c_str() << '\n';
-				std::cout << "It is neither a NETURAL nor a " << ConverterFromCardClassToString.at(deckClass).c_str() << '\n';
-				continue;
-			}
-
-			card->ShowInfo();
-
-			const bool isYes = InputYesNo("Is it correct? ");
-			if (isYes == false)
-			{
-				continue;
-			}
-
-			ShowMenu(m_deckOperationStr);
-			const size_t selectedOperation = InputMenuNum("What do you want to do? ", CREATE_DECK_MENU_SIZE);
-
-			if (selectedOperation != CREATE_DECK_MENU_SIZE)
-			{
-				m_deckOperationFuncs[selectedOperation - 1](*this, deck, selectedCardID);
-			}
-			else
-			{
-				break;
+				std::cout << " doesn't exist. Try again.\n";
 			}
 		}
 	}
@@ -398,6 +361,9 @@ namespace Hearthstonepp
 		ShowMenu(m_mainMenuStr);
 		const size_t selectedNum = InputMenuNum("Select: ", MAIN_MENU_SIZE);
 		bool isFinish = false;
+
+		// Set flag that you do not need to return the card.
+		m_searchMode = SearchMode::JustSearch;
 
 		m_mainMenuFuncs[selectedNum - 1](*this);
 

--- a/Sources/Programs/Console.h
+++ b/Sources/Programs/Console.h
@@ -44,6 +44,12 @@ namespace Hearthstonepp
 		int Main();
 
 	private:
+		enum class SearchMode
+		{
+			JustSearch,
+			AddCardInDeck,
+		};
+
 		template<std::size_t SIZE>
 		void ShowMenu(std::array<std::string, SIZE>& menus);
 		void ShowSearchCardUsage() const;
@@ -118,7 +124,9 @@ namespace Hearthstonepp
 			&Console::DeleteCardInDeck
 		};
 
-		Player* m_player;
+		SearchMode m_searchMode = SearchMode::JustSearch;
+
+		Player* m_player = nullptr;
 	};
 }
 

--- a/Sources/Programs/Console.h
+++ b/Sources/Programs/Console.h
@@ -51,7 +51,7 @@ namespace Hearthstonepp
 		bool InputYesNo(std::string sentence) const;
 
 		std::tuple<SearchFilter, bool, bool> InputAndParseSearchCommand(std::string commandStr) const;
-		std::vector<Card*> ProcessSearchCommand(SearchFilter filter);
+		std::vector<Card*> ProcessSearchCommand(SearchFilter filter) const;
 
 		std::vector<std::string> SplitString(std::string str, std::string delimiter) const;
 

--- a/Sources/Programs/Console.h
+++ b/Sources/Programs/Console.h
@@ -16,6 +16,7 @@
 
 #include <array>
 #include <functional>
+#include <optional>
 
 namespace Hearthstonepp
 {
@@ -25,7 +26,7 @@ namespace Hearthstonepp
 		void SignIn();
 		void SignUp();
 
-		void SearchCard();
+		std::optional<Card*> SearchCard();
 		int ManageDeck();
 		void SimulateGame();
 		void Leave();

--- a/Sources/Programs/Console.h
+++ b/Sources/Programs/Console.h
@@ -125,6 +125,7 @@ namespace Hearthstonepp
 		};
 
 		SearchMode m_searchMode = SearchMode::JustSearch;
+		CardClass m_deckClass = CardClass::INVALID;
 
 		Player* m_player = nullptr;
 	};

--- a/Sources/Programs/Console.h
+++ b/Sources/Programs/Console.h
@@ -35,10 +35,10 @@ namespace Hearthstonepp
 		void ModifyDeck();
 		void DeleteDeck();
 
-		void OperateDeck(size_t selectedDeck);
+		int OperateDeck(size_t deckIndex);
 
-		void AddCardInDeck(Deck* deck, std::string& selectedCardID);
-		void DeleteCardInDeck(Deck* deck, std::string& selectedCardID);
+		void AddCardInDeck(size_t deckIndex);
+		void DeleteCardInDeck(size_t deckIndex);
 
 		int Login();
 		int Main();
@@ -118,7 +118,7 @@ namespace Hearthstonepp
 			"2. Delete Card(s)",
 			"3. Back"
 		};
-		std::array<std::function<void(Console&, Deck*, std::string&)>, CREATE_DECK_MENU_SIZE - 1> m_deckOperationFuncs =
+		std::array<std::function<void(Console&, size_t)>, CREATE_DECK_MENU_SIZE - 1> m_deckOperationFuncs =
 		{
 			&Console::AddCardInDeck,
 			&Console::DeleteCardInDeck


### PR DESCRIPTION
카드 검색 시스템을 개량하는 작업을 진행했습니다.
먼저 카드 검색 함수와 덱에 카드를 추가하는 함수를 연결하는 작업을 했습니다.
덱에 카드를 추가할 때 카드 정보를 간략하게 보여주기 위한 ShowBriefInfo 함수를 구현했습니다.
그리고 SearchCard 함수를 두 군데에서 사용하기 때문에 검색 모드를 추가했습니다.
검색 모드에 따라 카드를 검색할 때, 그리고 검색한 뒤의 동작이 달라집니다.
이를 위해 C++17의 ```std::optional```을 사용했습니다. 이 부분은 레퍼런스 사이트를 참고해주세요.
마지막으로 덱에서 카드를 삭제할 때, 플레이어 정보를 저장할 때 발생하는 런타임 오류를 수정했습니다.