### PR TITLE
Fix CMake build system - Fix compile and link error in Ubuntu Linux (#41)

### DIFF
--- a/Builds/CMake/CompileOptions.cmake
+++ b/Builds/CMake/CompileOptions.cmake
@@ -8,7 +8,7 @@ string(TOUPPER ${CMAKE_SYSTEM_NAME} SYSTEM_NAME_UPPER)
 # Determine architecture (32/64 bit)
 set(X64 OFF)
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-    set(X64 ON)
+	set(X64 ON)
 endif()
 
 #
@@ -16,9 +16,9 @@ endif()
 #
 
 set(DEFAULT_PROJECT_OPTIONS
-    CXX_STANDARD              17 # Not available before CMake 3.8.2; see below for manual command line argument addition
-    LINKER_LANGUAGE           "CXX"
-    POSITION_INDEPENDENT_CODE ON
+	CXX_STANDARD              17 # Not available before CMake 3.8.2; see below for manual command line argument addition
+	LINKER_LANGUAGE           "CXX"
+	POSITION_INDEPENDENT_CODE ON
 )
 
 #
@@ -38,15 +38,15 @@ set(DEFAULT_LIBRARIES)
 #
 
 set(DEFAULT_COMPILE_DEFINITIONS
-    SYSTEM_${SYSTEM_NAME_UPPER}
+	SYSTEM_${SYSTEM_NAME_UPPER}
 )
 
 # MSVC compiler options
 if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-    set(DEFAULT_COMPILE_DEFINITIONS ${DEFAULT_COMPILE_DEFINITIONS}
-        _SCL_SECURE_NO_WARNINGS  # Calling any one of the potentially unsafe methods in the Standard C++ Library
-        _CRT_SECURE_NO_WARNINGS  # Calling any one of the potentially unsafe methods in the CRT Library
-    )
+	set(DEFAULT_COMPILE_DEFINITIONS ${DEFAULT_COMPILE_DEFINITIONS}
+		_SCL_SECURE_NO_WARNINGS  # Calling any one of the potentially unsafe methods in the Standard C++ Library
+		_CRT_SECURE_NO_WARNINGS  # Calling any one of the potentially unsafe methods in the CRT Library
+	)
 endif ()
 
 #
@@ -57,45 +57,45 @@ set(DEFAULT_COMPILE_OPTIONS)
 
 # MSVC compiler options
 if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-    # remove default warning level from CMAKE_CXX_FLAGS
-    string (REGEX REPLACE "/W[0-4]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+	# remove default warning level from CMAKE_CXX_FLAGS
+	string (REGEX REPLACE "/W[0-4]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 endif()
 
 # MSVC compiler options
 if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-    set(DEFAULT_COMPILE_OPTIONS ${DEFAULT_COMPILE_OPTIONS}
-        /MP           # -> build with multiple processes
-        /W3           # -> warning level 3
-        # /WX         # -> treat warnings as errors
+	set(DEFAULT_COMPILE_OPTIONS ${DEFAULT_COMPILE_OPTIONS}
+		/MP           # -> build with multiple processes
+		/W4           # -> warning level 3
+		# /WX         # -> treat warnings as errors
 
-        # /wd4251     # -> disable warning: 'identifier': class 'type' needs to have dll-interface to be used by clients of class 'type2'
-        # /wd4592     # -> disable warning: 'identifier': symbol will be dynamically initialized (implementation limitation)
-        # /wd4201     # -> disable warning: nonstandard extension used: nameless struct/union (caused by GLM)
-        # /wd4127     # -> disable warning: conditional expression is constant (caused by Qt)
-        /wd4717       # -> disable warning: recursive on all control paths, function will cause runtime stack overflow (wrong warning)
+		# /wd4251     # -> disable warning: 'identifier': class 'type' needs to have dll-interface to be used by clients of class 'type2'
+		# /wd4592     # -> disable warning: 'identifier': symbol will be dynamically initialized (implementation limitation)
+		# /wd4201     # -> disable warning: nonstandard extension used: nameless struct/union (caused by GLM)
+		# /wd4127     # -> disable warning: conditional expression is constant (caused by Qt)
+		/wd4717       # -> disable warning: recursive on all control paths, function will cause runtime stack overflow (wrong warning)
 
-        #$<$<CONFIG:Debug>:
-        #/RTCc        # -> value is assigned to a smaller data type and results in a data loss
-        #>
+		#$<$<CONFIG:Debug>:
+		#/RTCc        # -> value is assigned to a smaller data type and results in a data loss
+		#>
 
-        $<$<CONFIG:Release>:
-        /Gw           # -> whole program global optimization
-        /GS-          # -> buffer security check: no
-        /GL           # -> whole program optimization: enable link-time code generation (disables Zi)
-        /GF           # -> enable string pooling
-        >
+		$<$<CONFIG:Release>:
+		/Gw           # -> whole program global optimization
+		/GS-          # -> buffer security check: no
+		/GL           # -> whole program optimization: enable link-time code generation (disables Zi)
+		/GF           # -> enable string pooling
+		>
 
-        # No manual c++11 enable for MSVC as all supported MSVC versions for cmake-init have C++11 implicitly enabled (MSVC >=2013)
-    )
+		# No manual c++11 enable for MSVC as all supported MSVC versions for cmake-init have C++11 implicitly enabled (MSVC >=2013)
+	)
 endif ()
 
 # GCC and Clang compiler options
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set(DEFAULT_COMPILE_OPTIONS ${DEFAULT_COMPILE_OPTIONS}
-        -Wall
-        -Werror
-        -std=c++1z
-    )
+	set(DEFAULT_COMPILE_OPTIONS ${DEFAULT_COMPILE_OPTIONS}
+		-Wall
+		# -Werror
+		-std=c++1z
+	)
 endif ()
 
 #
@@ -106,7 +106,8 @@ set(DEFAULT_LINKER_OPTIONS)
 
 # Use pthreads on mingw and linux
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_SYSTEM_NAME MATCHES "Linux")
-    set(DEFAULT_LINKER_OPTIONS
-        -pthread
-    )
+	set(DEFAULT_LINKER_OPTIONS
+		-pthread
+		-lstdc++fs
+	)
 endif()

--- a/Includes/Commons/Constants.h
+++ b/Includes/Commons/Constants.h
@@ -9,16 +9,18 @@
 #ifndef HEARTHSTONEPP_CONSTANTS_H
 #define HEARTHSTONEPP_CONSTANTS_H
 
+#include <cstddef>
+
 namespace Hearthstonepp
 {
 	constexpr float VERSION = 0.1f;
 
-	constexpr size_t LOGIN_MENU_SIZE = 3;
-	constexpr size_t MAIN_MENU_SIZE = 4;
-	constexpr size_t MANAGE_DECK_MENU_SIZE = 4;
-	constexpr size_t CREATE_DECK_MENU_SIZE = 3;
+	constexpr std::size_t LOGIN_MENU_SIZE = 3;
+	constexpr std::size_t MAIN_MENU_SIZE = 4;
+	constexpr std::size_t MANAGE_DECK_MENU_SIZE = 4;
+	constexpr std::size_t CREATE_DECK_MENU_SIZE = 3;
 
-	constexpr size_t PLAYER_CLASS_SIZE = 9;
+	constexpr std::size_t PLAYER_CLASS_SIZE = 9;
 	constexpr unsigned int MAXIMUM_NUM_CARDS_IN_DECK = 30;
 
 	constexpr unsigned int NUM_BEGIN_DRAW = 3;

--- a/Includes/Commons/Macros.h
+++ b/Includes/Commons/Macros.h
@@ -1,0 +1,23 @@
+/*************************************************************************
+> File Name: Macros.h
+> Project Name: Hearthstone++
+> Author: Chan-Ho Chris Ohk
+> Purpose: Macro lists for Hearthstone++.
+> Created Time: 2017/12/26
+> Copyright (c) 2017, Chan-Ho Chris Ohk
+*************************************************************************/
+#ifndef HEARTHSTONEPP_MACROS_H
+#define HEARTHSTONEPP_MACROS_H
+
+#if defined(_WIN32) || defined(_WIN64)
+#   define HEARTHSTONEPP_WINDOWS
+#elif defined(__APPLE__)
+#   define HEARTHSTONEPP_APPLE
+#   ifndef HEARTHSTONEPP_IOS
+#       define HEARTHSTONEPP_MACOSX
+#   endif
+#elif defined(linux) || defined(__linux__)
+#   define HEARTHSTONEPP_LINUX
+#endif
+
+#endif

--- a/Includes/Models/Card.h
+++ b/Includes/Models/Card.h
@@ -12,6 +12,7 @@
 #include <Enums/Enums.h>
 
 #include <map>
+#include <string>
 #include <vector>
 
 namespace Hearthstonepp

--- a/Programs/Console/Console.cpp
+++ b/Programs/Console/Console.cpp
@@ -10,6 +10,7 @@
 
 #include <Agents/GameAgent.h>
 #include <Commons/Constants.h>
+#include <Commons/Macros.h>
 #include <Commons/Utils.h>
 #include <Enums/EnumsToString.h>
 #include <Interface/Interface.h>
@@ -18,7 +19,11 @@
 #include <Models/Card.h>
 #include <Models/Cards.h>
 
+#ifdef HEARTHSTONEPP_WINDOWS
 #include <filesystem>
+#else
+#include <experimental/filesystem>
+#endif
 #include <fstream>
 #include <iostream>
 
@@ -493,13 +498,26 @@ namespace Hearthstonepp
 			argv[i] = new char[16];
 		}
 
+#ifdef HEARTHSTONEPP_WINDOWS
 		argv[0] = _strdup("Hearthstone++");
+#else
+		argv[0] = strdup("Hearthstone++");
+#endif
 
+#ifdef HEARTHSTONEPP_WINDOWS
 		char* nextToken = strtok_s(searchInput, delimiter, &context);
+#else
+		char* nextToken = strtok_r(searchInput, delimiter, &context);
+#endif
 		while (nextToken != nullptr)
 		{
+#ifdef HEARTHSTONEPP_WINDOWS
 			argv[argc] = _strdup(nextToken);
 			nextToken = strtok_s(context, delimiter, &context);
+#else
+			argv[argc] = strdup(nextToken);
+			nextToken = strtok_r(context, delimiter, &context);
+#endif
 			argc++;
 		}
 

--- a/Sources/Agents/GameAgent.cpp
+++ b/Sources/Agents/GameAgent.cpp
@@ -9,6 +9,8 @@
 #include <Agents/GameAgent.h>
 #include <Commons/Constants.h>
 
+#include <algorithm>
+
 namespace Hearthstonepp
 {
 	GameAgent::GameAgent(User& user1, User& user2, int maxBufferSize) :
@@ -77,7 +79,7 @@ namespace Hearthstonepp
 	void GameAgent::DecideDeckOrder()
 	{
 		// get random number, zero or one.
-		const std::uniform_int_distribution<int> bin(0, 1);
+		std::uniform_int_distribution<int> bin(0, 1);
 		if (bin(m_generator) == 1) // swap user with 50% probability
 		{
 			std::swap(m_userCurrent, m_userOpponent);

--- a/Sources/Loaders/PlayerLoader.cpp
+++ b/Sources/Loaders/PlayerLoader.cpp
@@ -6,11 +6,16 @@
 > Created Time: 2017/10/19
 > Copyright (c) 2017, Chan-Ho Chris Ohk
 *************************************************************************/
+#include <Commons/Macros.h>
 #include <Enums/EnumsToString.h>
 #include <Enums/StringToEnums.h>
 #include <Loaders/PlayerLoader.h>
 
+#ifdef HEARTHSTONEPP_WINDOWS
 #include <filesystem>
+#else
+#include <experimental/filesystem>
+#endif
 #include <fstream>
 #include <iostream>
 

--- a/Sources/Models/Card.cpp
+++ b/Sources/Models/Card.cpp
@@ -9,6 +9,7 @@
 #include <Enums/EnumsToString.h>
 #include <Models/Card.h>
 
+#include <algorithm>
 #include <iostream>
 
 namespace Hearthstonepp


### PR DESCRIPTION
Ubuntu Linux에서 Hearthstone++ 프로젝트를 빌드할 때 컴파일 및 링크 오류가 발생해,
Windows Subsystems for Linux (WSL)에서 이 문제를 확인한 뒤 오류를 수정했습니다.
플랫폼을 구분하기 위한 매크로 헤더 파일을 추가하고 플랫폼에 따라 로직을 분리했습니다.